### PR TITLE
fix(rpc): bound feeder gateway trace fallback with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `--rpc.gateway-trace-timeout` CLI option (default 30s) bounding how long `starknet_traceTransaction` and `starknet_traceBlockTransactions` may spend on the feeder gateway fallback path.
+
 ### Fixed
 
 - `--max-rpc-connections` is now shared across all routes.
+- `starknet_traceTransaction` and `starknet_traceBlockTransactions` requests that fall back to the feeder gateway could hang indefinitely on a slow or unresponsive sequencer (the gateway client retries transport errors with an unbounded exponential backoff), holding RPC tasks and letting a public-network client exhaust the RPC concurrency budget. These requests are now bounded by `--rpc.gateway-trace-timeout` and bail out early on graceful shutdown.
 
 ## [0.23.1] - 2026-08-03
 

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -274,6 +274,7 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
         submission_tracker_time_limit: config.submission_tracker_time_limit,
         submission_tracker_size_limit: config.submission_tracker_size_limit,
         block_trace_cache_size: config.rpc_block_trace_cache_size,
+        gateway_trace_timeout: config.rpc_gateway_trace_timeout,
         compiler_concurrency_limit,
         compiler_resource_limits: config.compiler_resource_limits,
         blockifier_libfuncs: config.blockifier_libfuncs,

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -610,6 +610,19 @@ Setting this value too low may cause compilation of large classes to fail.",
     )]
     rpc_block_trace_cache_size: std::num::NonZeroUsize,
 
+    #[arg(
+        long = "rpc.gateway-trace-timeout",
+        value_name = "Seconds",
+        long_help = "Maximum duration a `trace_transaction` or `trace_block_transactions` request \
+                     may spend on the feeder gateway fallback path. The gateway client retries \
+                     transport errors with an unbounded exponential backoff, so this ceiling \
+                     prevents a slow or unresponsive sequencer from holding RPC tasks for the \
+                     full retry policy.",
+        default_value = "30",
+        env = "PATHFINDER_RPC_GATEWAY_TRACE_TIMEOUT"
+    )]
+    rpc_gateway_trace_timeout: std::num::NonZeroU64,
+
     #[cfg_attr(
         all(
             feature = "consensus-integration-tests",
@@ -1197,6 +1210,7 @@ pub struct Config {
     pub submission_tracker_time_limit: NonZeroU64,
     pub submission_tracker_size_limit: NonZeroUsize,
     pub rpc_block_trace_cache_size: NonZeroUsize,
+    pub rpc_gateway_trace_timeout: Duration,
     pub consensus: Option<ConsensusConfig>,
     /// Integration testing config, only available on debug builds with `p2p`
     /// and `consensus-integration-tests` features enabled.
@@ -1519,6 +1533,7 @@ impl Config {
             submission_tracker_time_limit: args.submission_tracker_time_limit,
             submission_tracker_size_limit: args.submission_tracker_size_limit,
             rpc_block_trace_cache_size: args.rpc_block_trace_cache_size,
+            rpc_gateway_trace_timeout: Duration::from_secs(args.rpc_gateway_trace_timeout.get()),
             consensus: ConsensusConfig::parse_or_exit(args.consensus),
             integration_testing: integration_testing::IntegrationTestingConfig::parse(
                 args.integration_testing,

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -82,6 +82,12 @@ pub struct RpcConfig {
     pub submission_tracker_time_limit: NonZeroU64,
     pub submission_tracker_size_limit: NonZeroUsize,
     pub block_trace_cache_size: NonZeroUsize,
+    /// Upper bound on how long a single trace request may wait on the feeder
+    /// gateway fallback path. The gateway client retries transport errors with
+    /// an unbounded exponential backoff, so without this ceiling a slow or
+    /// unresponsive sequencer holds the RPC task (and its preflight resources)
+    /// for the full retry policy — a public-network slot-exhaustion primitive.
+    pub gateway_trace_timeout: Duration,
     pub compiler_concurrency_limit: NonZeroUsize,
     pub compiler_resource_limits: pathfinder_compiler::ResourceLimits,
     pub blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs,
@@ -266,6 +272,7 @@ impl RpcContext {
             submission_tracker_time_limit: NonZeroU64::new(300).unwrap(),
             submission_tracker_size_limit: NonZeroUsize::new(30000).unwrap(),
             block_trace_cache_size: NonZeroUsize::new(1).unwrap(),
+            gateway_trace_timeout: Duration::from_secs(30),
             compiler_concurrency_limit: NonZeroUsize::new(1).unwrap(),
             compiler_resource_limits: pathfinder_compiler::ResourceLimits::for_test(),
             blockifier_libfuncs: pathfinder_compiler::BlockifierLibfuncs::default(),

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -240,34 +240,54 @@ pub async fn trace_block_transactions(
         LocalExecution::Unsupported((block_id, transactions)) => (block_id, transactions),
     };
 
-    context
-        .sequencer
-        .block_traces(block_id.into())
-        .await
-        .context("Forwarding to feeder gateway")
-        .map_err(TraceBlockTransactionsError::from)
-        .map(|trace| {
-            let traces = trace
-                .traces
-                .into_iter()
-                .zip(transactions)
-                .map(|(trace, tx)| Ok((tx.hash, map_gateway_trace(tx, trace)?)))
-                .collect::<Result<Vec<_>, TraceBlockTransactionsError>>()?;
-            let output_format = if return_initial_reads {
-                TraceOutputFormat::Object {
-                    traces,
-                    // Gateway traces do not include initial reads.
-                    initial_reads: None,
-                }
-            } else {
-                TraceOutputFormat::Array(traces)
-            };
-            Ok(TraceBlockTransactionsOutput {
-                output_format,
-                // State diffs are not available for traces fetched from the gateway.
-                include_state_diffs: false,
-            })
-        })?
+    // The gateway client retries transport errors with an unbounded exponential
+    // backoff, so a slow or unresponsive sequencer would otherwise hold this task
+    // (and the resources acquired during the preflight) for the full retry
+    // policy. Bound the fallback with an operator-tunable timeout and bail out
+    // early on graceful shutdown so the RPC slot is freed promptly.
+    let cancellation_token = util::task::cancellation_token();
+    let trace = tokio::select! {
+        biased;
+        _ = cancellation_token.cancelled() => {
+            return Err(TraceBlockTransactionsError::Internal(anyhow::anyhow!(
+                "Cancelled due to graceful shutdown"
+            )));
+        }
+        result = tokio::time::timeout(
+            context.config.gateway_trace_timeout,
+            context.sequencer.block_traces(block_id.into()),
+        ) => {
+            result
+                .map_err(|_| {
+                    TraceBlockTransactionsError::Custom(anyhow::anyhow!(
+                        "Timed out fetching block traces from the feeder gateway"
+                    ))
+                })?
+                .context("Forwarding to feeder gateway")
+                .map_err(TraceBlockTransactionsError::from)?
+        }
+    };
+
+    let traces = trace
+        .traces
+        .into_iter()
+        .zip(transactions)
+        .map(|(trace, tx)| Ok((tx.hash, map_gateway_trace(tx, trace)?)))
+        .collect::<Result<Vec<_>, TraceBlockTransactionsError>>()?;
+    let output_format = if return_initial_reads {
+        TraceOutputFormat::Object {
+            traces,
+            // Gateway traces do not include initial reads.
+            initial_reads: None,
+        }
+    } else {
+        TraceOutputFormat::Array(traces)
+    };
+    Ok(TraceBlockTransactionsOutput {
+        output_format,
+        // State diffs are not available for traces fetched from the gateway.
+        include_state_diffs: false,
+    })
 }
 
 pub(crate) fn map_gateway_trace(

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -244,11 +244,32 @@ pub async fn trace_transaction(
         LocalExecution::Unsupported(tx) => tx,
     };
 
-    let trace = context
-        .sequencer
-        .transaction_trace(input.transaction_hash)
-        .await
-        .context("Proxying call to feeder gateway")?;
+    // The gateway client retries transport errors with an unbounded exponential
+    // backoff, so a slow or unresponsive sequencer would otherwise hold this task
+    // (and the resources acquired during the preflight) for the full retry
+    // policy. Bound the fallback with an operator-tunable timeout and bail out
+    // early on graceful shutdown so the RPC slot is freed promptly.
+    let cancellation_token = util::task::cancellation_token();
+    let trace = tokio::select! {
+        biased;
+        _ = cancellation_token.cancelled() => {
+            return Err(TraceTransactionError::Internal(anyhow::anyhow!(
+                "Cancelled due to graceful shutdown"
+            )));
+        }
+        result = tokio::time::timeout(
+            context.config.gateway_trace_timeout,
+            context.sequencer.transaction_trace(input.transaction_hash),
+        ) => {
+            result
+                .map_err(|_| {
+                    TraceTransactionError::Custom(anyhow::anyhow!(
+                        "Timed out fetching transaction trace from the feeder gateway"
+                    ))
+                })?
+                .context("Proxying call to feeder gateway")?
+        }
+    };
 
     let trace = map_gateway_trace(transaction, trace)?;
 


### PR DESCRIPTION
trace_transaction and trace_block_transactions fall back to the feeder gateway for mainnet-window blocks and pre-0.14.0 versions. The gateway client retries transport errors with an unbounded exponential backoff, so a slow or unresponsive sequencer could hold the async RPC task forever. Because spawn_blocking cannot be cancelled by dropping its JoinHandle, a client disconnect did not free the task either, letting a public-network client exhaust the RPC concurrency budget with 32-byte tx-hash requests.

Wrap the gateway fallback calls in tokio::time::timeout bounded by a new operator-tunable --rpc.gateway-trace-timeout option (default 30s), and race the global shutdown CancellationToken so requests bail out early on graceful shutdown.