### PR TITLE
feat(rpc): restrict the number of websocket connections and other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--rpc.gateway-trace-timeout` CLI option (default 30s) bounding how long `starknet_traceTransaction` and `starknet_traceBlockTransactions` may spend on the feeder gateway fallback path.
+- **BREAKING**: The RPC server now pings websocket peers that have been quiet for `--rpc.websocket.ping-interval` and closes connections that leave `--rpc.websocket.max-missed-pings` pings unanswered. Clients are required to answer pings, which RFC 6455 mandates and which browsers and the mainstream websocket libraries handle for you, but only while the client is reading from the connection. A client that stops reading for longer than the ping interval times the missed ping limit is disconnected. The keepalive cannot be turned off, so `--rpc.websocket.ping-interval`, `--rpc.websocket.initial-frame-timeout` and `--rpc.websocket.max-missed-pings` all reject `0`. Raise the ping interval rather than trying to disable it.
 - Concurrently open RPC websocket connections are now limited to 1024 by default, configurable with the `--rpc.websocket.max-connections` CLI option. Upgrade requests over the limit are rejected with HTTP 503.
 - RPC websocket connections that don't send anything after being established now time out, configurable with the `--rpc.websocket.initial-frame-timeout` CLI option.
-- The RPC server now pings websocket peers that have been quiet for `--rpc.websocket.ping-interval` and closes connections that leave `--rpc.websocket.max-missed-pings` pings unanswered.
 - New metrics: `rpc_websocket_connections` (gauge), `rpc_websocket_connections_rejected_total` and `rpc_websocket_connections_closed_total` (labelled with `reason`).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--rpc.gateway-trace-timeout` CLI option (default 30s) bounding how long `starknet_traceTransaction` and `starknet_traceBlockTransactions` may spend on the feeder gateway fallback path.
+- Concurrently open RPC websocket connections are now limited to 1024 by default, configurable with the `--rpc.websocket.max-connections` CLI option. Upgrade requests over the limit are rejected with HTTP 503.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--rpc.gateway-trace-timeout` CLI option (default 30s) bounding how long `starknet_traceTransaction` and `starknet_traceBlockTransactions` may spend on the feeder gateway fallback path.
 - Concurrently open RPC websocket connections are now limited to 1024 by default, configurable with the `--rpc.websocket.max-connections` CLI option. Upgrade requests over the limit are rejected with HTTP 503.
+- RPC websocket connections that don't send anything after being established now time out, configurable with the `--rpc.websocket.initial-frame-timeout` CLI option.
+- The RPC server now pings websocket peers that have been quiet for `--rpc.websocket.ping-interval` and closes connections that leave `--rpc.websocket.max-missed-pings` pings unanswered.
+- New metrics: `rpc_websocket_connections` (gauge), `rpc_websocket_connections_rejected_total` and `rpc_websocket_connections_closed_total` (labelled with `reason`).
 
 ### Fixed
 
 - `--max-rpc-connections` is now shared across all routes.
 - A batch request could open more subscriptions than `--rpc.websocket.max-subscriptions` allows, because the requests within a batch are handled concurrently and each of them checked the limit before any of them counted towards it.
 - `starknet_traceTransaction` and `starknet_traceBlockTransactions` requests that fall back to the feeder gateway could hang indefinitely on a slow or unresponsive sequencer (the gateway client retries transport errors with an unbounded exponential backoff), holding RPC tasks and letting a public-network client exhaust the RPC concurrency budget. These requests are now bounded by `--rpc.gateway-trace-timeout` and bail out early on graceful shutdown.
+- Subscriptions are now torn down when their websocket connection closes, instead of when they next try to send.
 
 ## [0.23.1] - 2026-08-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9084,6 +9084,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -303,6 +303,9 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
             initial_frame_timeout: config.websocket.initial_frame_timeout,
             ping_interval: config.websocket.ping_interval,
             max_missed_pings: config.websocket.max_missed_pings,
+            connection_limit: Arc::new(tokio::sync::Semaphore::new(
+                config.websocket.max_connections.get(),
+            )),
         })
     } else {
         context

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -295,12 +295,15 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
     );
 
     let context = if config.websocket.enabled {
-        context.with_websockets(WebsocketContext::new(
-            config.websocket.max_history.into(),
-            config.websocket.max_subscriptions.get(),
-            config.websocket.subscription_request_max_size.get(),
-            config.websocket.send_timeout,
-        ))
+        context.with_websockets(WebsocketContext {
+            max_history: config.websocket.max_history.into(),
+            max_subscriptions: config.websocket.max_subscriptions.get(),
+            subscription_max_size: config.websocket.subscription_request_max_size.get(),
+            send_timeout: config.websocket.send_timeout,
+            initial_frame_timeout: config.websocket.initial_frame_timeout,
+            ping_interval: config.websocket.ping_interval,
+            max_missed_pings: config.websocket.max_missed_pings,
+        })
     } else {
         context
     };

--- a/crates/pathfinder/src/bin/pathfinder/main.rs
+++ b/crates/pathfinder/src/bin/pathfinder/main.rs
@@ -32,6 +32,7 @@ use pathfinder_rpc::{Notifications, SyncState};
 use pathfinder_storage::Storage;
 use starknet_gateway_client::GatewayApi;
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::Semaphore;
 use tokio::task::JoinError;
 use tracing::info;
 
@@ -303,8 +304,12 @@ Hint: This is usually caused by exceeding the file descriptor limit of your syst
             initial_frame_timeout: config.websocket.initial_frame_timeout,
             ping_interval: config.websocket.ping_interval,
             max_missed_pings: config.websocket.max_missed_pings,
-            connection_limit: Arc::new(tokio::sync::Semaphore::new(
-                config.websocket.max_connections.get(),
+            connection_limit: Arc::new(Semaphore::new(
+                config
+                    .websocket
+                    .max_connections
+                    .get()
+                    .min(Semaphore::MAX_PERMITS),
             )),
         })
     } else {

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -815,6 +815,14 @@ fn parse_fractional_seconds(s: &str) -> Result<Duration, String> {
     Ok(duration)
 }
 
+fn parse_positive_fractional_seconds(s: &str) -> Result<Duration, String> {
+    let duration = parse_fractional_seconds(s)?;
+    if duration.is_zero() {
+        return Err("Expected a number greater than zero".to_string());
+    }
+    Ok(duration)
+}
+
 #[cfg(feature = "p2p")]
 fn parse_felt(s: &str) -> Result<Felt, String> {
     let felt = Felt::from_hex_str(s).map_err(|e| ToString::to_string(&e))?;
@@ -1595,19 +1603,19 @@ Note that the 'unlimited' setting is meant primarily for testing and not recomme
     #[arg(
         long = "rpc.websocket.initial-frame-timeout",
         long_help = "Websocket connections that don't send any frame within this many seconds of \
-                     being established are closed. Set to 0 to disable.",
+                     being established are closed. Must be greater than zero.",
         default_value = "30",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_WEBSOCKET_INITIAL_FRAME_TIMEOUT"
     )]
     pub initial_frame_timeout: Duration,
     #[arg(
         long = "rpc.websocket.ping-interval",
         long_help = "How many seconds to wait for a frame from the client before sending a \
-                     websocket ping to check that it is still alive. Set to 0 to disable the \
-                     keepalive.",
+                     websocket ping to check that it is still alive. Clients are required to \
+                     answer pings. Must be greater than zero.",
         default_value = "30",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_WEBSOCKET_PING_INTERVAL"
     )]
     pub ping_interval: Duration,
@@ -1618,7 +1626,7 @@ Note that the 'unlimited' setting is meant primarily for testing and not recomme
         default_value = "2",
         env = "PATHFINDER_WEBSOCKET_MAX_MISSED_PINGS"
     )]
-    pub max_missed_pings: u32,
+    pub max_missed_pings: NonZeroU32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1658,6 +1666,26 @@ mod tests {
 
     use super::{AllowedOrigins, RpcCorsDomainsParseError};
     use crate::config::{parse_cors, ParseVersionedConstantsError};
+
+    #[test]
+    fn websocket_keepalive_rejects_zero() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            websocket: super::WebsocketConfig,
+        }
+
+        for arg in [
+            "--rpc.websocket.ping-interval",
+            "--rpc.websocket.initial-frame-timeout",
+            "--rpc.websocket.max-missed-pings",
+        ] {
+            assert!(TestCli::try_parse_from(["pathfinder", arg, "0"]).is_err());
+            assert!(TestCli::try_parse_from(["pathfinder", arg, "1"]).is_ok());
+        }
+    }
 
     #[test]
     fn parse_cors_domains() {

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -231,7 +231,7 @@ Examples:
         long = "rpc.request-timeout",
         long_help = "Maximum RPC request duration in seconds.",
         default_value = "120",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_RPC_REQUEST_TIMEOUT"
     )]
     rpc_request_timeout: Duration,
@@ -240,7 +240,7 @@ Examples:
         long = "rpc.header-read-timeout",
         long_help = "Maximum time to send RPC request headers, in seconds.",
         default_value = "30",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_RPC_HEADER_READ_TIMEOUT"
     )]
     rpc_header_read_timeout: Duration,
@@ -249,7 +249,7 @@ Examples:
         long = "sync.poll-interval",
         long_help = "New block poll interval in seconds (can use fractions)",
         default_value = "1",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_HEAD_POLL_INTERVAL_SECONDS"
     )]
     poll_interval: Duration,
@@ -807,16 +807,11 @@ fn parse_fee_estimation_epsilon(s: &str) -> Result<Percentage, String> {
     Ok(Percentage::new(value))
 }
 
-fn parse_fractional_seconds(s: &str) -> Result<Duration, String> {
+fn parse_positive_fractional_seconds(s: &str) -> Result<Duration, String> {
     let seconds: f64 = s
         .parse()
         .map_err(|_| "Expected a number (f64)".to_string())?;
     let duration = Duration::try_from_secs_f64(seconds).map_err(|e| e.to_string())?;
-    Ok(duration)
-}
-
-fn parse_positive_fractional_seconds(s: &str) -> Result<Duration, String> {
-    let duration = parse_fractional_seconds(s)?;
     if duration.is_zero() {
         return Err("Expected a number greater than zero".to_string());
     }
@@ -1588,7 +1583,7 @@ Note that the 'unlimited' setting is meant primarily for testing and not recomme
         long = "rpc.websocket.send-timeout",
         long_help = "Threshold for considering the websocket's output buffer full (and closing the connection).",
         default_value = "1",
-        value_parser = parse_fractional_seconds,
+        value_parser = parse_positive_fractional_seconds,
         env = "PATHFINDER_WEBSOCKET_SEND_TIMEOUT"
     )]
     pub send_timeout: Duration,

--- a/crates/pathfinder/src/config.rs
+++ b/crates/pathfinder/src/config.rs
@@ -1584,6 +1584,41 @@ Note that the 'unlimited' setting is meant primarily for testing and not recomme
         env = "PATHFINDER_WEBSOCKET_SEND_TIMEOUT"
     )]
     pub send_timeout: Duration,
+    #[arg(
+        long = "rpc.websocket.max-connections",
+        long_help = "Sets the limit for the number of concurrent websocket connections. Upgrade \
+                     requests over the limit are rejected with HTTP 503.",
+        default_value = "1024",
+        env = "PATHFINDER_WEBSOCKET_MAX_CONNECTIONS"
+    )]
+    pub max_connections: NonZeroUsize,
+    #[arg(
+        long = "rpc.websocket.initial-frame-timeout",
+        long_help = "Websocket connections that don't send any frame within this many seconds of \
+                     being established are closed. Set to 0 to disable.",
+        default_value = "30",
+        value_parser = parse_fractional_seconds,
+        env = "PATHFINDER_WEBSOCKET_INITIAL_FRAME_TIMEOUT"
+    )]
+    pub initial_frame_timeout: Duration,
+    #[arg(
+        long = "rpc.websocket.ping-interval",
+        long_help = "How many seconds to wait for a frame from the client before sending a \
+                     websocket ping to check that it is still alive. Set to 0 to disable the \
+                     keepalive.",
+        default_value = "30",
+        value_parser = parse_fractional_seconds,
+        env = "PATHFINDER_WEBSOCKET_PING_INTERVAL"
+    )]
+    pub ping_interval: Duration,
+    #[arg(
+        long = "rpc.websocket.max-missed-pings",
+        long_help = "Number of consecutive unanswered pings after which a websocket connection is \
+                     closed.",
+        default_value = "2",
+        env = "PATHFINDER_WEBSOCKET_MAX_MISSED_PINGS"
+    )]
+    pub max_missed_pings: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -46,6 +46,7 @@ starknet-types-core = { workspace = true }
 starknet_api = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "process"] }
+tokio-util = { workspace = true }
 tower = { workspace = true, features = ["filter", "util", "limit", "timeout"] }
 tower-http = { workspace = true, features = ["cors", "limit", "request-id", "trace", "util"] }
 tracing = { workspace = true }

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -225,8 +225,13 @@ pub async fn rpc_handler(
 
             ws.max_message_size(ws_cfg.subscription_max_size)
                 .on_upgrade(async move |ws| {
-                    let (ws_tx, ws_rx) = split_ws(ws, state.version, &ws_cfg, connection_guard);
+                    // Axum drives this closure for as long as the socket is open, so
+                    // holding the guard here frees the connection's slot exactly when
+                    // the socket is closed.
+                    let _connection_guard = connection_guard;
+                    let (ws_tx, ws_rx, socket) = split_ws(ws, state.version, &ws_cfg);
                     handle_json_rpc_socket(state, ws_tx, ws_rx);
+                    socket.closed().await;
                 })
         }
         Err(_) => {

--- a/crates/rpc/src/jsonrpc/router.rs
+++ b/crates/rpc/src/jsonrpc/router.rs
@@ -211,16 +211,21 @@ pub async fn rpc_handler(
 ) -> impl axum::response::IntoResponse {
     match ws {
         Ok(ws) => {
-            let (send_timeout, subscription_max_size) = match state.context.websocket {
-                Some(ref ws_cfg) => (ws_cfg.send_timeout, ws_cfg.subscription_max_size),
-                None => {
-                    return StatusCode::FORBIDDEN.into_response();
-                }
+            let Some(ws_cfg) = state.context.websocket.clone() else {
+                return StatusCode::FORBIDDEN.into_response();
             };
 
-            ws.max_message_size(subscription_max_size)
+            // Reserve the slot before upgrading. A client over the limit then
+            // gets a rejection instead of a socket that closes immediately.
+            let Some(connection_guard) = ws_cfg.try_acquire_connection() else {
+                metrics::counter!("rpc_websocket_connections_rejected_total").increment(1);
+                tracing::debug!("Rejecting websocket upgrade: connection limit reached");
+                return StatusCode::SERVICE_UNAVAILABLE.into_response();
+            };
+
+            ws.max_message_size(ws_cfg.subscription_max_size)
                 .on_upgrade(async move |ws| {
-                    let (ws_tx, ws_rx) = split_ws(ws, state.version, send_timeout);
+                    let (ws_tx, ws_rx) = split_ws(ws, state.version, &ws_cfg, connection_guard);
                     handle_json_rpc_socket(state, ws_tx, ws_rx);
                 })
         }

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -18,7 +18,7 @@ use super::{run_concurrently, RpcRouter};
 use crate::context::RpcContext;
 use crate::dto::{DeserializeForVersion, SerializeForVersion};
 use crate::error::ApplicationError;
-use crate::jsonrpc::websocket::{ConnectionGuard, WebsocketContext, WebsocketHistory};
+use crate::jsonrpc::websocket::{WebsocketContext, WebsocketHistory};
 use crate::jsonrpc::{RpcError, RpcRequest, RpcResponse};
 use crate::types::request::SubscriptionBlockId;
 use crate::{RpcVersion, SubscriptionId};
@@ -93,6 +93,49 @@ impl Subscriptions {
             .next_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         SubscriptionId(id)
+    }
+
+    /// Aborts all of the subscriptions.
+    ///
+    /// Subscription tasks are only reachable through
+    /// [`tokio::task::JoinHandle`]s, which do not abort on drop. A task notices
+    /// that its connection is gone when its next send fails, and a quiet
+    /// subscription never sends again. Each task also holds a websocket sender,
+    /// which holds the connection's slot in
+    /// [`WebsocketContext::connection_limit`]. Each task needs to be aborted so
+    /// that the connection slot is freed.
+    pub fn abort_all(&self) {
+        // Remove the handles before aborting them. `abort` can drop the task's
+        // future inline, which runs its `SubscriptionEntryGuard` and reenters
+        // `remove`. That could deadlock the `subscriptions` `DashMap`.
+        let ids: Vec<_> = self
+            .subscriptions
+            .iter()
+            .map(|entry| *entry.key())
+            .collect();
+        for id in ids {
+            if let Some((_, handle)) = self.subscriptions.remove(&id) {
+                handle.abort();
+            }
+        }
+    }
+}
+
+/// Aborts a connection's subscriptions once its read loop is done.
+struct ConnectionSubscriptionsGuard(Arc<Subscriptions>);
+
+impl Drop for ConnectionSubscriptionsGuard {
+    fn drop(&mut self) {
+        self.0.abort_all();
+    }
+}
+
+/// Ties a task's lifetime to the scope holding this guard.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
     }
 }
 
@@ -293,7 +336,7 @@ where
         .map_err(|e| RpcError::InternalError(e.into()))??;
 
         Ok(util::task::spawn(async move {
-            let _subscription_guard = SubscriptionsGuard {
+            let _subscription_guard = SubscriptionEntryGuard {
                 subscription_id,
                 subscriptions,
                 _slot: slot,
@@ -347,7 +390,10 @@ where
 
             // Subscribe to new blocks. Receive the first subscription message.
             let (tx1, mut rx1) = mpsc::channel::<SubscriptionMessage<T::Notification>>(1024);
-            util::task::spawn({
+            // Only the outer task is tracked in `Subscriptions`, so we need to use a guard
+            // to make sure the inner task is aborted with it. This matters for subscriptions
+            // that have nothing to send via `tx1`.
+            let _subscribe_task = AbortOnDrop(util::task::spawn({
                 let params = params.clone();
                 let context = router.context.clone();
                 let rpc_version = router.version;
@@ -358,7 +404,7 @@ where
                     }
                     tracing::trace!("Subscription task exited");
                 }
-            }.instrument(tracing::debug_span!("subscribe_task")));
+            }.instrument(tracing::debug_span!("subscribe_task"))));
             let first_msg = match rx1.recv().await {
                 Some(msg) => msg,
                 None => {
@@ -431,7 +477,7 @@ where
 
 /// A guard to ensure that the subscription handle is removed when the
 /// subscription task corresponding to that handle returns.
-struct SubscriptionsGuard {
+struct SubscriptionEntryGuard {
     subscription_id: SubscriptionId,
     subscriptions: Arc<Subscriptions>,
     /// The slot reserved by [`Subscriptions::try_reserve`], held for as long as
@@ -439,7 +485,7 @@ struct SubscriptionsGuard {
     _slot: OwnedSemaphorePermit,
 }
 
-impl Drop for SubscriptionsGuard {
+impl Drop for SubscriptionEntryGuard {
     fn drop(&mut self) {
         self.subscriptions.remove(&self.subscription_id);
     }
@@ -447,6 +493,23 @@ impl Drop for SubscriptionsGuard {
 
 type WsSender = mpsc::Sender<Result<Message, RpcResponse>>;
 type WsReceiver = mpsc::Receiver<Result<Message, axum::Error>>;
+
+/// The two tasks that own the halves of a websocket, as returned by
+/// [`split_ws`].
+pub struct SocketTasks {
+    sender: tokio::task::JoinHandle<()>,
+    reader: tokio::task::JoinHandle<()>,
+}
+
+impl SocketTasks {
+    /// Waits until the socket is closed.
+    ///
+    /// [`WebSocket::split`] gives both halves a `BiLock` on the socket, so the
+    /// socket is closed once both of these tasks are gone, and not before.
+    pub async fn closed(self) {
+        let _ = tokio::join!(self.sender, self.reader);
+    }
+}
 
 /// Split a websocket into an MPSC sender and receiver.
 /// These two are later passed to [`handle_json_rpc_socket`]. This separation
@@ -457,22 +520,15 @@ pub fn split_ws(
     ws: WebSocket,
     version: RpcVersion,
     ws_cfg: &WebsocketContext,
-    connection_guard: ConnectionGuard,
-) -> (WsSender, WsReceiver) {
-    // `WebSocket::split` gives both halves a `BiLock` on the socket, so the socket
-    // closes only once both tasks below are gone. Both tasks hold a clone of the
-    // guard, so the connection's slot is freed by whichever one ends last.
-    let connection_guard = Arc::new(connection_guard);
+) -> (WsSender, WsReceiver, SocketTasks) {
     let egress_timeout = ws_cfg.send_timeout;
     let (mut ws_sender, mut ws_receiver) = ws.split();
     let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
     // Send messages to the websocket using an MPSC channel.
     let (sender_tx, mut sender_rx) = mpsc::channel::<Result<Message, RpcResponse>>(1024);
-    util::task::spawn_with_cancel({
-        let connection_guard = connection_guard.clone();
+    let sender_task = util::task::spawn_with_cancel({
         move |cancellation_token| {
             async move {
-                let _connection_guard = connection_guard;
                 loop {
                     tokio::select! {
                         _ = cancellation_token.cancelled() => {
@@ -512,8 +568,7 @@ pub fn split_ws(
     });
     // Receive messages from the websocket using an MPSC channel.
     let (receiver_tx, receiver_rx) = mpsc::channel::<Result<Message, axum::Error>>(1024);
-    util::task::spawn(async move {
-        let _connection_guard = connection_guard;
+    let reader_task = util::task::spawn(async move {
         while let Some(msg) = ws_receiver.next().await {
             if let Err(e) = receiver_tx.send(msg).await {
                 tracing::debug!(error=?e, "Error sending incoming websocket over channel");
@@ -521,7 +576,11 @@ pub fn split_ws(
             }
         }
     });
-    (sender_tx, receiver_rx)
+    let tasks = SocketTasks {
+        sender: sender_task,
+        reader: reader_task,
+    };
+    (sender_tx, receiver_rx, tasks)
 }
 
 pub fn handle_json_rpc_socket(
@@ -538,6 +597,9 @@ pub fn handle_json_rpc_socket(
     let subscriptions = Arc::new(Subscriptions::new(max_subscriptions));
     // Read and handle messages from the websocket.
     util::task::spawn(async move {
+        // The read loop returns when the connection is gone, and the guard is to make sure
+        // all subscriptions are properly cleaned up.
+        let _abort_subscriptions_for_this_connection = ConnectionSubscriptionsGuard(Arc::clone(&subscriptions));
         loop {
             let request = match ws_rx.recv().await {
                 Some(Ok(Message::Text(msg))) => msg.as_str().to_string(),
@@ -1162,6 +1224,40 @@ mod tests {
             response = request(4, "test", serde_json::json!({})).await;
         }
         assert!(response["result"].is_string());
+    }
+
+    /// A quiet subscription has nothing to send, so it never notices that its
+    /// connection is gone. Closing the connection aborts it explicitly.
+    #[tokio::test]
+    async fn closing_the_connection_aborts_its_subscriptions() {
+        let router = setup(0, WebsocketHistory::Unlimited, NeverEnds).await;
+        let (sender_tx, mut sender_rx) = mpsc::channel(1024);
+        let (receiver_tx, receiver_rx) = mpsc::channel(1024);
+        handle_json_rpc_socket(router.clone(), sender_tx, receiver_rx);
+        receiver_tx
+            .send(Ok(Message::Text(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "test",
+                    "params": {}
+                })
+                .to_string()
+                .into(),
+            )))
+            .await
+            .unwrap();
+        // Wait for the subscription to start.
+        sender_rx.recv().await.unwrap().unwrap();
+
+        // Close the connection. Aborting the subscription task drops the sender
+        // it holds, which closes the channel.
+        drop(receiver_tx);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while sender_rx.recv().await.is_some() {}
+        })
+        .await
+        .expect("the subscription outlived the connection");
     }
 
     #[tokio::test]

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -505,7 +505,7 @@ pub struct SocketTasks {
 impl SocketTasks {
     /// Waits until the socket is closed.
     ///
-    /// [`WebSocket::split`] gives both halves a `BiLock` on the socket, so the
+    /// `WebSocket::split` gives both halves a `BiLock` on the socket, so the
     /// socket is closed once both of these tasks are gone, and not before.
     pub async fn closed(self) {
         let _ = tokio::join!(self.sender, self.reader);

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -12,6 +12,7 @@ use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock, Semaphore};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use super::{run_concurrently, RpcRouter};
@@ -522,11 +523,19 @@ pub fn split_ws(
     ws_cfg: &WebsocketContext,
 ) -> (WsSender, WsReceiver, SocketTasks) {
     let egress_timeout = ws_cfg.send_timeout;
+    // The reader cancels this to bring the sender task down with it. Neither task
+    // can close the socket alone.
+    let connection_token = CancellationToken::new();
+    // `Duration::ZERO` disables these, so both are `Option`s.
+    let initial_frame_timeout = Some(ws_cfg.initial_frame_timeout).filter(|d| !d.is_zero());
+    let ping_interval = Some(ws_cfg.ping_interval).filter(|d| !d.is_zero());
+    let max_missed_pings = ws_cfg.max_missed_pings;
     let (mut ws_sender, mut ws_receiver) = ws.split();
     let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
     // Send messages to the websocket using an MPSC channel.
     let (sender_tx, mut sender_rx) = mpsc::channel::<Result<Message, RpcResponse>>(1024);
     let sender_task = util::task::spawn_with_cancel({
+        let connection_token = connection_token.clone();
         move |cancellation_token| {
             async move {
                 loop {
@@ -536,6 +545,15 @@ pub fn split_ws(
                             let _ = send_with_timeout(Message::Close(Some(CloseFrame {
                                 code: close_code::NORMAL,
                                 reason: Utf8Bytes::from_static("Server shutdown"),
+                            }))).await.ok();
+                            break;
+                        }
+                        _ = connection_token.cancelled() => {
+                            // A `CancellationToken` carries no payload, so the precise reason
+                            // stays in the reader's log.
+                            let _ = send_with_timeout(Message::Close(Some(CloseFrame {
+                                code: close_code::NORMAL,
+                                reason: Utf8Bytes::from_static("Connection idle"),
                             }))).await.ok();
                             break;
                         }
@@ -568,12 +586,57 @@ pub fn split_ws(
     });
     // Receive messages from the websocket using an MPSC channel.
     let (receiver_tx, receiver_rx) = mpsc::channel::<Result<Message, axum::Error>>(1024);
-    let reader_task = util::task::spawn(async move {
-        while let Some(msg) = ws_receiver.next().await {
-            if let Err(e) = receiver_tx.send(msg).await {
-                tracing::debug!(error=?e, "Error sending incoming websocket over channel");
-                break;
-            }
+    let reader_task = util::task::spawn({
+        let ping_tx = sender_tx.clone();
+        async move {
+            // A subscribed client only receives, so silence does not mean the
+            // peer is gone. An unused connection gets the shorter deadline until
+            // its first frame. After that the server pings to check on the peer.
+            let mut deadline = initial_frame_timeout;
+            let mut awaiting_first_frame = true;
+            let mut missed_pings = 0;
+            let close_reason = loop {
+                let received = match deadline {
+                    Some(deadline) => match timeout(deadline, ws_receiver.next()).await {
+                        Ok(received) => received,
+                        Err(_) => {
+                            if awaiting_first_frame {
+                                break "no_initial_frame";
+                            }
+                            missed_pings += 1;
+                            if missed_pings > max_missed_pings {
+                                break "unresponsive";
+                            }
+                            if ping_tx
+                                .send(Ok(Message::Ping(Default::default())))
+                                .await
+                                .is_err()
+                            {
+                                break "closing";
+                            }
+                            continue;
+                        }
+                    },
+                    None => ws_receiver.next().await,
+                };
+                let Some(msg) = received else {
+                    break "peer";
+                };
+                awaiting_first_frame = false;
+                deadline = ping_interval;
+                missed_pings = 0;
+                if let Err(e) = receiver_tx.send(msg).await {
+                    tracing::debug!(error=?e, "Error sending incoming websocket over channel");
+                    break "closing";
+                }
+            };
+            tracing::debug!(reason = close_reason, "Websocket connection closed");
+            metrics::counter!(
+                "rpc_websocket_connections_closed_total",
+                "reason" => close_reason,
+            )
+            .increment(1);
+            connection_token.cancel();
         }
     });
     let tasks = SocketTasks {
@@ -1253,7 +1316,7 @@ mod tests {
         // Close the connection. Aborting the subscription task drops the sender
         // it holds, which closes the channel.
         drop(receiver_tx);
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while sender_rx.recv().await.is_some() {}
         })
         .await

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use async_trait::async_trait;
 use axum::extract::ws::{close_code, CloseFrame, Message, Utf8Bytes, WebSocket};
 use dashmap::DashMap;
@@ -530,7 +531,12 @@ pub fn split_ws(
     let ping_interval = ws_cfg.ping_interval;
     let max_missed_pings = ws_cfg.max_missed_pings.get();
     let (mut ws_sender, mut ws_receiver) = ws.split();
-    let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
+
+    let mut send_with_timeout =
+        async move |msg| match timeout(egress_timeout, ws_sender.send(msg)).await {
+            Ok(sent) => sent.context("Sending websocket message"),
+            Err(_) => anyhow::bail!("Sending websocket message timed out"),
+        };
     // Send messages to the websocket using an MPSC channel.
     let (sender_tx, mut sender_rx) = mpsc::channel::<Result<Message, RpcResponse>>(1024);
     let sender_task = util::task::spawn_with_cancel({
@@ -580,6 +586,7 @@ pub fn split_ws(
                         }
                     }
                 }
+                connection_token.cancel();
             }
         }
     });
@@ -595,31 +602,39 @@ pub fn split_ws(
             // connection open by refreshing it with control frames.
             let first_frame_deadline = Instant::now() + initial_frame_timeout;
             let mut awaiting_first_frame = true;
-            let mut missed_pings = 0;
+            let mut silent_intervals = 0;
             let close_reason = loop {
                 let deadline = if awaiting_first_frame {
                     first_frame_deadline
                 } else {
                     Instant::now() + ping_interval
                 };
-                let received = match timeout_at(deadline, ws_receiver.next()).await {
-                    Ok(received) => received,
-                    Err(_) => {
-                        if awaiting_first_frame {
-                            break "no_initial_frame";
+
+                let received = tokio::select! {
+                    _ = connection_token.cancelled() => {
+                        break "closing";
+                    }
+                    received = timeout_at(deadline, ws_receiver.next()) => {
+                        match received {
+                            Ok(received) => received,
+                            Err(_) => {
+                                if awaiting_first_frame {
+                                    break "no_initial_frame";
+                                }
+                                silent_intervals += 1;
+                                if silent_intervals > max_missed_pings {
+                                    break "unresponsive";
+                                }
+                                if ping_tx
+                                    .send(Ok(Message::Ping(Default::default())))
+                                    .await
+                                    .is_err()
+                                {
+                                    break "closing";
+                                }
+                                continue;
+                            }
                         }
-                        missed_pings += 1;
-                        if missed_pings > max_missed_pings {
-                            break "unresponsive";
-                        }
-                        if ping_tx
-                            .send(Ok(Message::Ping(Default::default())))
-                            .await
-                            .is_err()
-                        {
-                            break "closing";
-                        }
-                        continue;
                     }
                 };
                 let Some(msg) = received else {
@@ -631,7 +646,7 @@ pub fn split_ws(
                 if matches!(msg, Ok(Message::Text(_) | Message::Binary(_))) {
                     awaiting_first_frame = false;
                 }
-                missed_pings = 0;
+                silent_intervals = 0;
                 if let Err(e) = receiver_tx.send(msg).await {
                     tracing::debug!(error=?e, "Error sending incoming websocket over channel");
                     break "closing";

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -526,10 +526,9 @@ pub fn split_ws(
     // The reader cancels this to bring the sender task down with it. Neither task
     // can close the socket alone.
     let connection_token = CancellationToken::new();
-    // `Duration::ZERO` disables these, so both are `Option`s.
-    let initial_frame_timeout = Some(ws_cfg.initial_frame_timeout).filter(|d| !d.is_zero());
-    let ping_interval = Some(ws_cfg.ping_interval).filter(|d| !d.is_zero());
-    let max_missed_pings = ws_cfg.max_missed_pings;
+    let initial_frame_timeout = ws_cfg.initial_frame_timeout;
+    let ping_interval = ws_cfg.ping_interval;
+    let max_missed_pings = ws_cfg.max_missed_pings.get();
     let (mut ws_sender, mut ws_receiver) = ws.split();
     let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
     // Send messages to the websocket using an MPSC channel.
@@ -596,28 +595,25 @@ pub fn split_ws(
             let mut awaiting_first_frame = true;
             let mut missed_pings = 0;
             let close_reason = loop {
-                let received = match deadline {
-                    Some(deadline) => match timeout(deadline, ws_receiver.next()).await {
-                        Ok(received) => received,
-                        Err(_) => {
-                            if awaiting_first_frame {
-                                break "no_initial_frame";
-                            }
-                            missed_pings += 1;
-                            if missed_pings > max_missed_pings {
-                                break "unresponsive";
-                            }
-                            if ping_tx
-                                .send(Ok(Message::Ping(Default::default())))
-                                .await
-                                .is_err()
-                            {
-                                break "closing";
-                            }
-                            continue;
+                let received = match timeout(deadline, ws_receiver.next()).await {
+                    Ok(received) => received,
+                    Err(_) => {
+                        if awaiting_first_frame {
+                            break "no_initial_frame";
                         }
-                    },
-                    None => ws_receiver.next().await,
+                        missed_pings += 1;
+                        if missed_pings > max_missed_pings {
+                            break "unresponsive";
+                        }
+                        if ping_tx
+                            .send(Ok(Message::Ping(Default::default())))
+                            .await
+                            .is_err()
+                        {
+                            break "closing";
+                        }
+                        continue;
+                    }
                 };
                 let Some(msg) = received else {
                     break "peer";

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -11,14 +11,14 @@ use pathfinder_serde::AsBoundedVec;
 use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock, Semaphore};
-use tokio::time::{timeout, Duration};
+use tokio::time::timeout;
 use tracing::Instrument;
 
 use super::{run_concurrently, RpcRouter};
 use crate::context::RpcContext;
 use crate::dto::{DeserializeForVersion, SerializeForVersion};
 use crate::error::ApplicationError;
-use crate::jsonrpc::websocket::WebsocketHistory;
+use crate::jsonrpc::websocket::{ConnectionGuard, WebsocketContext, WebsocketHistory};
 use crate::jsonrpc::{RpcError, RpcRequest, RpcResponse};
 use crate::types::request::SubscriptionBlockId;
 use crate::{RpcVersion, SubscriptionId};
@@ -456,42 +456,52 @@ type WsReceiver = mpsc::Receiver<Result<Message, axum::Error>>;
 pub fn split_ws(
     ws: WebSocket,
     version: RpcVersion,
-    egress_timeout: Duration,
+    ws_cfg: &WebsocketContext,
+    connection_guard: ConnectionGuard,
 ) -> (WsSender, WsReceiver) {
+    // `WebSocket::split` gives both halves a `BiLock` on the socket, so the socket
+    // closes only once both tasks below are gone. Both tasks hold a clone of the
+    // guard, so the connection's slot is freed by whichever one ends last.
+    let connection_guard = Arc::new(connection_guard);
+    let egress_timeout = ws_cfg.send_timeout;
     let (mut ws_sender, mut ws_receiver) = ws.split();
     let mut send_with_timeout = async move |msg| timeout(egress_timeout, ws_sender.send(msg)).await;
     // Send messages to the websocket using an MPSC channel.
     let (sender_tx, mut sender_rx) = mpsc::channel::<Result<Message, RpcResponse>>(1024);
-    util::task::spawn_with_cancel(move |cancellation_token| {
-        async move {
-            loop {
-                tokio::select! {
-                    _ = cancellation_token.cancelled() => {
-                        // Ignore the error since we're shutting down anyway.
-                        let _ = send_with_timeout(Message::Close(Some(CloseFrame {
-                            code: close_code::NORMAL,
-                            reason: Utf8Bytes::from_static("Server shutdown"),
-                        }))).await.ok();
-                        break;
-                    }
-                    msg = sender_rx.recv() => {
-                        let Some(msg) = msg else {
+    util::task::spawn_with_cancel({
+        let connection_guard = connection_guard.clone();
+        move |cancellation_token| {
+            async move {
+                let _connection_guard = connection_guard;
+                loop {
+                    tokio::select! {
+                        _ = cancellation_token.cancelled() => {
+                            // Ignore the error since we're shutting down anyway.
+                            let _ = send_with_timeout(Message::Close(Some(CloseFrame {
+                                code: close_code::NORMAL,
+                                reason: Utf8Bytes::from_static("Server shutdown"),
+                            }))).await.ok();
                             break;
-                        };
-                        match msg {
-                            Ok(msg) => {
-                                if let Err(e) = send_with_timeout(msg).await {
-                                    tracing::debug!(error=?e, "Error sending websocket message");
-                                    break;
+                        }
+                        msg = sender_rx.recv() => {
+                            let Some(msg) = msg else {
+                                break;
+                            };
+                            match msg {
+                                Ok(msg) => {
+                                    if let Err(e) = send_with_timeout(msg).await {
+                                        tracing::debug!(error=?e, "Error sending websocket message");
+                                        break;
+                                    }
                                 }
-                            }
-                            Err(e) => {
-                                let data = serde_json::to_string(&e.serialize(crate::dto::Serializer::new(version)).unwrap()).unwrap();
-                                if let Err(e) = send_with_timeout(Message::Text(data.into()))
-                                    .await
-                                {
-                                    tracing::debug!(error=?e, "Error sending websocket error message");
-                                    break;
+                                Err(e) => {
+                                    let data = serde_json::to_string(&e.serialize(crate::dto::Serializer::new(version)).unwrap()).unwrap();
+                                    if let Err(e) = send_with_timeout(Message::Text(data.into()))
+                                        .await
+                                    {
+                                        tracing::debug!(error=?e, "Error sending websocket error message");
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -503,6 +513,7 @@ pub fn split_ws(
     // Receive messages from the websocket using an MPSC channel.
     let (receiver_tx, receiver_rx) = mpsc::channel::<Result<Message, axum::Error>>(1024);
     util::task::spawn(async move {
+        let _connection_guard = connection_guard;
         while let Some(msg) = ws_receiver.next().await {
             if let Err(e) = receiver_tx.send(msg).await {
                 tracing::debug!(error=?e, "Error sending incoming websocket over channel");

--- a/crates/rpc/src/jsonrpc/router/subscription.rs
+++ b/crates/rpc/src/jsonrpc/router/subscription.rs
@@ -11,7 +11,7 @@ use pathfinder_serde::AsBoundedVec;
 use serde::de::DeserializeSeed as _;
 use serde_json::value::RawValue;
 use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock, Semaphore};
-use tokio::time::timeout;
+use tokio::time::{timeout, timeout_at, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
@@ -589,13 +589,20 @@ pub fn split_ws(
         let ping_tx = sender_tx.clone();
         async move {
             // A subscribed client only receives, so silence does not mean the
-            // peer is gone. An unused connection gets the shorter deadline until
-            // its first frame. After that the server pings to check on the peer.
-            let mut deadline = initial_frame_timeout;
+            // peer is gone. An unused connection has until `first_frame_deadline`
+            // to send a request. After that the server pings to check on the
+            // peer. The first deadline is absolute, so a client cannot hold the
+            // connection open by refreshing it with control frames.
+            let first_frame_deadline = Instant::now() + initial_frame_timeout;
             let mut awaiting_first_frame = true;
             let mut missed_pings = 0;
             let close_reason = loop {
-                let received = match timeout(deadline, ws_receiver.next()).await {
+                let deadline = if awaiting_first_frame {
+                    first_frame_deadline
+                } else {
+                    Instant::now() + ping_interval
+                };
+                let received = match timeout_at(deadline, ws_receiver.next()).await {
                     Ok(received) => received,
                     Err(_) => {
                         if awaiting_first_frame {
@@ -618,8 +625,12 @@ pub fn split_ws(
                 let Some(msg) = received else {
                     break "peer";
                 };
-                awaiting_first_frame = false;
-                deadline = ping_interval;
+                // A control frame shows the peer is alive but not that the
+                // connection is in use, so it does not satisfy the first frame
+                // deadline. It does still count as an answer to a ping.
+                if matches!(msg, Ok(Message::Text(_) | Message::Binary(_))) {
+                    awaiting_first_frame = false;
+                }
                 missed_pings = 0;
                 if let Err(e) = receiver_tx.send(msg).await {
                     tracing::debug!(error=?e, "Error sending incoming websocket over channel");

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -29,33 +29,43 @@ pub enum WebsocketHistory {
 #[derive(Clone)]
 pub struct WebsocketContext {
     pub max_history: WebsocketHistory,
+    /// Maximum number of subscriptions per connection.
     pub max_subscriptions: usize,
     pub subscription_max_size: usize,
     pub send_timeout: Duration,
+    /// The client has to send the first frame to the server within this
+    /// interval or the connection will be closed. [`Duration::ZERO`] disables
+    /// the timeout.
+    pub initial_frame_timeout: Duration,
+    /// The server waits this long for a frame from the client before sending a
+    /// ping. [`Duration::ZERO`] disables the keepalive.
+    pub ping_interval: Duration,
+    /// How many pings can be unanswered before the server closes the
+    /// connection.
+    pub max_missed_pings: u32,
+}
+
+impl Default for WebsocketContext {
+    fn default() -> Self {
+        Self {
+            max_history: WebsocketHistory::Limited(1024),
+            max_subscriptions: 1024,
+            subscription_max_size: 1024 * 1024,
+            send_timeout: Duration::from_secs(1),
+            initial_frame_timeout: Duration::from_secs(30),
+            ping_interval: Duration::from_secs(30),
+            max_missed_pings: 2,
+        }
+    }
 }
 
 impl WebsocketContext {
-    pub fn new(
-        max_history: WebsocketHistory,
-        max_subscriptions: usize,
-        subscription_max_size: usize,
-        send_timeout: Duration,
-    ) -> Self {
-        Self {
-            max_history,
-            max_subscriptions,
-            subscription_max_size,
-            send_timeout,
-        }
-    }
-
     #[cfg(test)]
     pub fn for_test(max_history: WebsocketHistory) -> Self {
         Self {
             max_history,
-            max_subscriptions: 1024,
-            subscription_max_size: 1024 * 1024,
             send_timeout: Duration::from_secs_f64(0.1),
+            ..Default::default()
         }
     }
 }

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -18,6 +18,7 @@
 //! < {"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x66626f1f0038c608f8d4ee10c39c9d4f0b98a9866b086cb32e8f919ee6b43aa","block_number":11834642,"event_commitment":"0x0","event_count":0,"l1_da_mode":"BLOB","l1_data_gas_price":{"price_in_fri":"0x10a3324ecd","price_in_wei":"0x11b45d"},"l1_gas_price":{"price_in_fri":"0x411936095dbe","price_in_wei":"0x45460c02"},"l2_gas_price":{"price_in_fri":"0x712f2ffc7","price_in_wei":"0x78718"},"new_root":"0x4cfd667f0ab6ab2e6041564b0b11288e0eb4b81b53d5301c53ea21667d937be","parent_hash":"0x668a2e83e0daeb3036a80a3007d44f0b8153d1f21209bb82fabdeaf45238a8b","receipt_commitment":"0x0","sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","starknet_version":"0.14.3","state_diff_commitment":"0x5d2704f07aae8cbd3cfcfe831d9d735198b7499a38817cb5dc5f23217340b91","state_diff_length":1,"timestamp":1784019750,"transaction_commitment":"0x0","transaction_count":0},"subscription_id":"0"}}
 //! ```
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -37,15 +38,16 @@ pub struct WebsocketContext {
     pub subscription_max_size: usize,
     pub send_timeout: Duration,
     /// The client has to send the first frame to the server within this
-    /// interval or the connection will be closed. [`Duration::ZERO`] disables
-    /// the timeout.
+    /// interval or the connection will be closed. Must be greater than zero, or
+    /// connections are closed as soon as they are established.
     pub initial_frame_timeout: Duration,
     /// The server waits this long for a frame from the client before sending a
-    /// ping. [`Duration::ZERO`] disables the keepalive.
+    /// ping. Must be greater than zero, or connections are closed as soon as
+    /// they are established.
     pub ping_interval: Duration,
     /// How many pings can be unanswered before the server closes the
     /// connection.
-    pub max_missed_pings: u32,
+    pub max_missed_pings: NonZeroU32,
     /// Limits how many websocket connections are open at once.
     pub connection_limit: Arc<Semaphore>,
 }
@@ -59,7 +61,7 @@ impl Default for WebsocketContext {
             send_timeout: Duration::from_secs(1),
             initial_frame_timeout: Duration::from_secs(30),
             ping_interval: Duration::from_secs(30),
-            max_missed_pings: 2,
+            max_missed_pings: NonZeroU32::new(2).expect("2 > 0"),
             connection_limit: Arc::new(Semaphore::new(1024)),
         }
     }

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -18,7 +18,10 @@
 //! < {"jsonrpc":"2.0","method":"starknet_subscriptionNewHeads","params":{"result":{"block_hash":"0x66626f1f0038c608f8d4ee10c39c9d4f0b98a9866b086cb32e8f919ee6b43aa","block_number":11834642,"event_commitment":"0x0","event_count":0,"l1_da_mode":"BLOB","l1_data_gas_price":{"price_in_fri":"0x10a3324ecd","price_in_wei":"0x11b45d"},"l1_gas_price":{"price_in_fri":"0x411936095dbe","price_in_wei":"0x45460c02"},"l2_gas_price":{"price_in_fri":"0x712f2ffc7","price_in_wei":"0x78718"},"new_root":"0x4cfd667f0ab6ab2e6041564b0b11288e0eb4b81b53d5301c53ea21667d937be","parent_hash":"0x668a2e83e0daeb3036a80a3007d44f0b8153d1f21209bb82fabdeaf45238a8b","receipt_commitment":"0x0","sequencer_address":"0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8","starknet_version":"0.14.3","state_diff_commitment":"0x5d2704f07aae8cbd3cfcfe831d9d735198b7499a38817cb5dc5f23217340b91","state_diff_length":1,"timestamp":1784019750,"transaction_commitment":"0x0","transaction_count":0},"subscription_id":"0"}}
 //! ```
 
+use std::sync::Arc;
 use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WebsocketHistory {
@@ -43,6 +46,8 @@ pub struct WebsocketContext {
     /// How many pings can be unanswered before the server closes the
     /// connection.
     pub max_missed_pings: u32,
+    /// Limits how many websocket connections are open at once.
+    pub connection_limit: Arc<Semaphore>,
 }
 
 impl Default for WebsocketContext {
@@ -55,11 +60,22 @@ impl Default for WebsocketContext {
             initial_frame_timeout: Duration::from_secs(30),
             ping_interval: Duration::from_secs(30),
             max_missed_pings: 2,
+            connection_limit: Arc::new(Semaphore::new(1024)),
         }
     }
 }
 
 impl WebsocketContext {
+    /// Reserves a slot for a new websocket connection. Returns [`None`] at the
+    /// limit. Dropping the returned [`ConnectionGuard`] frees the slot.
+    pub fn try_acquire_connection(&self) -> Option<ConnectionGuard> {
+        self.connection_limit
+            .clone()
+            .try_acquire_owned()
+            .ok()
+            .map(ConnectionGuard::new)
+    }
+
     #[cfg(test)]
     pub fn for_test(max_history: WebsocketHistory) -> Self {
         Self {
@@ -67,5 +83,20 @@ impl WebsocketContext {
             send_timeout: Duration::from_secs_f64(0.1),
             ..Default::default()
         }
+    }
+}
+
+pub struct ConnectionGuard(#[allow(dead_code)] OwnedSemaphorePermit);
+
+impl ConnectionGuard {
+    fn new(permit: OwnedSemaphorePermit) -> Self {
+        metrics::gauge!("rpc_websocket_connections").increment(1.0);
+        Self(permit)
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        metrics::gauge!("rpc_websocket_connections").decrement(1.0);
     }
 }

--- a/crates/rpc/src/jsonrpc/websocket.rs
+++ b/crates/rpc/src/jsonrpc/websocket.rs
@@ -82,8 +82,13 @@ impl WebsocketContext {
     pub fn for_test(max_history: WebsocketHistory) -> Self {
         Self {
             max_history,
+            max_subscriptions: 1024,
+            subscription_max_size: 1024 * 1024,
             send_timeout: Duration::from_secs_f64(0.1),
-            ..Default::default()
+            initial_frame_timeout: Duration::from_secs(30),
+            ping_interval: Duration::from_secs(30),
+            max_missed_pings: NonZeroU32::new(2).expect("2 > 0"),
+            connection_limit: Arc::new(Semaphore::new(1024)),
         }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1547,18 +1547,18 @@ mod tests {
 
         let (_jh, url) = ws_keepalive_server(|ws_ctx| {
             ws_ctx.initial_frame_timeout = Duration::from_millis(200);
-            // Isolate the initial deadline from the keepalive.
-            ws_ctx.ping_interval = Duration::ZERO;
+            // Long enough that the initial deadline is what closes the connection.
+            ws_ctx.ping_interval = Duration::from_secs(30);
         })
         .await;
 
         let (mut ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
         // Send nothing at all. The server must hang up on its own.
-        timeout(Duration::from_secs(5), async {
+        timeout(Duration::from_secs(1), async {
             while ws.next().await.transpose().unwrap_or(None).is_some() {}
         })
         .await
-        .expect("the server did not close an unused connection");
+        .unwrap()
     }
 
     /// A subscribed client only ever receives, and still counts as alive.
@@ -1591,7 +1591,7 @@ mod tests {
 
         // Sit through more than `max_missed_pings` intervals without sending
         // anything. Only pings should arrive and the connection should stay open.
-        let closed = timeout(Duration::from_secs(2), async {
+        let closed = timeout(Duration::from_secs(1), async {
             while let Some(msg) = ws.next().await {
                 if let tokio_tungstenite::tungstenite::Message::Close(_) = msg.unwrap() {
                     break;
@@ -1599,10 +1599,9 @@ mod tests {
             }
         })
         .await;
-        assert!(
-            closed.is_err(),
-            "a subscribed connection was closed while it was answering pings"
-        );
+        // We expect a timeout: connection is not closed, because it is exchanging
+        // pings.
+        assert!(closed.is_err());
     }
 
     #[tokio::test]
@@ -1613,7 +1612,7 @@ mod tests {
             // Long enough that it cannot be what closes the connection.
             ws_ctx.initial_frame_timeout = Duration::from_secs(30);
             ws_ctx.ping_interval = Duration::from_millis(100);
-            ws_ctx.max_missed_pings = 2;
+            ws_ctx.max_missed_pings = std::num::NonZeroU32::new(2).unwrap();
         })
         .await;
 
@@ -1632,11 +1631,11 @@ mod tests {
         .unwrap();
 
         // Leave the stream unpolled. `tokio_tungstenite` answers pings only while
-        // something polls it, so the peer looks unresponsive. Wait out more than
+        // something polls it, so the client looks unresponsive. Wait out more than
         // `max_missed_pings` intervals before reading what arrived.
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let closed = timeout(Duration::from_secs(5), async {
+        let closed = timeout(Duration::from_secs(1), async {
             while let Some(msg) = ws.next().await {
                 match msg {
                     Ok(tokio_tungstenite::tungstenite::Message::Close(_)) | Err(_) => break,
@@ -1645,11 +1644,8 @@ mod tests {
             }
         })
         .await;
-        assert!(
-            closed.is_ok(),
-            "an unresponsive connection was not closed after {} missed pings",
-            2
-        );
+        // Connection should be closed because the client did not answer pings.
+        assert!(closed.is_ok());
     }
 
     enum Api {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1561,6 +1561,48 @@ mod tests {
         .unwrap()
     }
 
+    #[tokio::test]
+    async fn websocket_that_only_sends_pongs_is_closed() {
+        use futures::{SinkExt, StreamExt};
+
+        let (_jh, url) = ws_keepalive_server(|ws_ctx| {
+            ws_ctx.initial_frame_timeout = Duration::from_millis(300);
+            // Long enough that the initial deadline is what closes the connection.
+            ws_ctx.ping_interval = Duration::from_secs(30);
+        })
+        .await;
+
+        let (ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+        let (mut ws_tx, mut ws_rx) = ws.split();
+
+        let pongs = tokio::spawn(async move {
+            loop {
+                if ws_tx
+                    .send(tokio_tungstenite::tungstenite::Message::Pong(
+                        Default::default(),
+                    ))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+
+        let closed = timeout(Duration::from_secs(2), async {
+            while let Some(msg) = ws_rx.next().await {
+                match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Close(_)) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await;
+        pongs.abort();
+        assert!(closed.is_ok());
+    }
+
     /// A subscribed client only ever receives, and still counts as alive.
     /// `tokio_tungstenite` answers the server's pings automatically.
     #[tokio::test]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1523,6 +1523,135 @@ mod tests {
         assert!(connected);
     }
 
+    /// Spawns a server with the websocket keepalive settings that `configure`
+    /// applies, and returns its websocket URL.
+    async fn ws_keepalive_server(
+        configure: impl FnOnce(&mut context::WebsocketContext),
+    ) -> (JoinHandle<anyhow::Result<()>>, String) {
+        use crate::jsonrpc::websocket::WebsocketHistory;
+
+        let mut ws_ctx = context::WebsocketContext::for_test(WebsocketHistory::Unlimited);
+        configure(&mut ws_ctx);
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let context = RpcContext::for_tests().with_websockets(ws_ctx);
+        let (jh, addr) = RpcServer::new(addr, context, RpcVersion::V09)
+            .spawn(&PathBuf::default())
+            .await
+            .unwrap();
+        (jh, format!("ws://{addr}/ws/rpc/v0_9"))
+    }
+
+    #[tokio::test]
+    async fn websocket_that_never_sends_a_frame_is_closed() {
+        use futures::StreamExt;
+
+        let (_jh, url) = ws_keepalive_server(|ws_ctx| {
+            ws_ctx.initial_frame_timeout = Duration::from_millis(200);
+            // Isolate the initial deadline from the keepalive.
+            ws_ctx.ping_interval = Duration::ZERO;
+        })
+        .await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+        // Send nothing at all. The server must hang up on its own.
+        timeout(Duration::from_secs(5), async {
+            while ws.next().await.transpose().unwrap_or(None).is_some() {}
+        })
+        .await
+        .expect("the server did not close an unused connection");
+    }
+
+    /// A subscribed client only ever receives, and still counts as alive.
+    /// `tokio_tungstenite` answers the server's pings automatically.
+    #[tokio::test]
+    async fn subscribed_websocket_that_sends_nothing_is_kept_open() {
+        use futures::{SinkExt, StreamExt};
+
+        let (_jh, url) = ws_keepalive_server(|ws_ctx| {
+            ws_ctx.initial_frame_timeout = Duration::from_millis(200);
+            ws_ctx.ping_interval = Duration::from_millis(100);
+        })
+        .await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewHeads",
+                "params": {}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        // The subscription confirmation.
+        ws.next().await.unwrap().unwrap();
+
+        // Sit through more than `max_missed_pings` intervals without sending
+        // anything. Only pings should arrive and the connection should stay open.
+        let closed = timeout(Duration::from_secs(2), async {
+            while let Some(msg) = ws.next().await {
+                if let tokio_tungstenite::tungstenite::Message::Close(_) = msg.unwrap() {
+                    break;
+                }
+            }
+        })
+        .await;
+        assert!(
+            closed.is_err(),
+            "a subscribed connection was closed while it was answering pings"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_that_does_not_answer_pings_is_closed() {
+        use futures::{SinkExt, StreamExt};
+
+        let (_jh, url) = ws_keepalive_server(|ws_ctx| {
+            // Long enough that it cannot be what closes the connection.
+            ws_ctx.initial_frame_timeout = Duration::from_secs(30);
+            ws_ctx.ping_interval = Duration::from_millis(100);
+            ws_ctx.max_missed_pings = 2;
+        })
+        .await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "starknet_subscribeNewHeads",
+                "params": {}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        // Leave the stream unpolled. `tokio_tungstenite` answers pings only while
+        // something polls it, so the peer looks unresponsive. Wait out more than
+        // `max_missed_pings` intervals before reading what arrived.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let closed = timeout(Duration::from_secs(5), async {
+            while let Some(msg) = ws.next().await {
+                match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Close(_)) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await;
+        assert!(
+            closed.is_ok(),
+            "an unresponsive connection was not closed after {} missed pings",
+            2
+        );
+    }
+
     enum Api {
         HttpOnly,
         WebsocketOnly,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1478,6 +1478,51 @@ mod tests {
         assert!(status.is_success());
     }
 
+    #[tokio::test]
+    async fn websocket_connections_are_limited() {
+        use std::sync::Arc;
+
+        use tokio::sync::Semaphore;
+
+        use crate::jsonrpc::websocket::WebsocketHistory;
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let context = RpcContext::for_tests().with_websockets(context::WebsocketContext {
+            connection_limit: Arc::new(Semaphore::new(1)),
+            ..context::WebsocketContext::for_test(WebsocketHistory::Unlimited)
+        });
+        let (_jh, addr) = RpcServer::new(addr, context, RpcVersion::V09)
+            .spawn(&PathBuf::default())
+            .await
+            .unwrap();
+
+        let url = format!("ws://{addr}/ws/rpc/v0_9");
+        let first = tokio_tungstenite::connect_async(url.clone()).await;
+        assert!(first.is_ok());
+
+        let err = tokio_tungstenite::connect_async(url.clone())
+            .await
+            .expect_err("the second connection should be rejected");
+        match err {
+            tokio_tungstenite::tungstenite::Error::Http(response) => {
+                assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+            }
+            other => panic!("Expected an HTTP 503, got {other:?}"),
+        }
+
+        // Closing the first connection frees its slot.
+        drop(first);
+        let mut connected = false;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if tokio_tungstenite::connect_async(url.clone()).await.is_ok() {
+                connected = true;
+                break;
+            }
+        }
+        assert!(connected);
+    }
+
     enum Api {
         HttpOnly,
         WebsocketOnly,

--- a/crates/rpc/src/method/subscribe_new_heads.rs
+++ b/crates/rpc/src/method/subscribe_new_heads.rs
@@ -189,7 +189,9 @@ mod tests {
 
     #[tokio::test]
     async fn reorg() {
-        let (_, mut rx, subscription_id, router) = happy_path_test(1).await;
+        // Keep the sender alive. Dropping it closes the connection, which tears
+        // down its subscriptions.
+        let (_receiver_tx, mut rx, subscription_id, router) = happy_path_test(1).await;
         router
             .context
             .notifications

--- a/crates/rpc/src/method/subscribe_transaction_status.rs
+++ b/crates/rpc/src/method/subscribe_transaction_status.rs
@@ -520,7 +520,7 @@ mod tests {
 
     #[tokio::test]
     async fn transaction_already_exists_in_db_accepted_on_l2_succeeded() {
-        let (router, mut rx, pending_data_cache, subscription_id) =
+        let (router, mut rx, pending_data_cache, subscription_id, _receiver_tx) =
             test_transaction_already_exists_in_db(
                 ExecutionStatus::Succeeded,
                 None,
@@ -1528,6 +1528,9 @@ mod tests {
         mpsc::Receiver<Result<Message, RpcResponse>>,
         std::sync::Arc<PendingDataCache>,
         SubscriptionId,
+        // Callers keep this to hold the connection open. Dropping it closes the
+        // connection and tears down its subscriptions.
+        mpsc::Sender<Result<Message, axum::Error>>,
     ) {
         let (router, pending_data_cache) = setup().await;
         let tx_hash = TARGET_TX_HASH;
@@ -1619,7 +1622,13 @@ mod tests {
         // No more messages expected.
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(sender_rx.try_recv().is_err());
-        (router, sender_rx, pending_data_cache, subscription_id)
+        (
+            router,
+            sender_rx,
+            pending_data_cache,
+            subscription_id,
+            receiver_tx,
+        )
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
This PR is a follow-up of https://github.com/equilibriumco/pathfinder/pull/3534, and addresses the rest of issues outlined in https://github.com/equilibriumco/pathfinder-audit/issues/1132.

This PR introduces the following changes:
1. Maximum number of concurrent websocket connections is now capped at the default 1024, configurable via `--rpc.websocket.max-connections`.
2. In order to clean up half-dead sockets keepalive is introduced. Otherwise the above permit limit could easily be exhausted. Keepalive behavior is built upon:
   a. `--rpc.websocket.initial-frame-timeout`, defaults to 30s, cannot be 0
   b. `--rpc.websocket.ping-interval`, defaults to 30s, cannot be 0
   c. `--rpc.websocket.max-missed-pings`, defaults to 2, cannot be 0
   d. This is a **breaking** change. From now on the client must reply with a `Pong` if we send a `Ping` otherwise the connection is closed, and the permit released.
3. New metrics: `rpc_websocket_connections` (gauge), `rpc_websocket_connections_rejected_total`, `rpc_websocket_connections_closed_total{reason}`.
4. Connections are now properly torn down, which is necessary for the connection limit not to be exhausted in malicious ways.
5. Upgrade requests that fall above the connection limit now end with HTTP 503, instead of upgrading and then closing the connection.
