### PR TITLE
fix(rpc): harden feeder-gateway trace fallback surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A batch request could open more subscriptions than `--rpc.websocket.max-subscriptions` allows, because the requests within a batch are handled concurrently and each of them checked the limit before any of them counted towards it.
 - `starknet_traceTransaction` and `starknet_traceBlockTransactions` requests that fall back to the feeder gateway could hang indefinitely on a slow or unresponsive sequencer (the gateway client retries transport errors with an unbounded exponential backoff), holding RPC tasks and letting a public-network client exhaust the RPC concurrency budget. These requests are now bounded by `--rpc.gateway-trace-timeout` and bail out early on graceful shutdown.
 - Subscriptions are now torn down when their websocket connection closes, instead of when they next try to send.
-
-### Security
-
 - Hardened the feeder-gateway trace fallback path used by `starknet_traceTransaction` and `starknet_traceBlockTransactions` for the mainnet block range where local re-execution is impossible. Any public-network caller can force this path for the affected blocks, so a compromised or byzantine gateway response is untrusted authoritative input. The trace deserialiser now bounds `internal_calls` nesting depth, caps the length of every `Vec<Felt>`/`Vec<Event>`/`Vec<MsgToL1>` field, and rejects unknown fields on `FunctionInvocation`; the trace mapper walks `internal_calls` iteratively instead of recursively (preventing a stack-overflow `SIGSEGV` that escapes the RPC layer's `catch_unwind`); and the resource counters are summed with checked arithmetic instead of `+`/`.unwrap()` (preventing overflow panics). The gateway fallback path is also logged with a `trace_source` marker.
 
 ## [0.23.1] - 2026-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `starknet_traceTransaction` and `starknet_traceBlockTransactions` requests that fall back to the feeder gateway could hang indefinitely on a slow or unresponsive sequencer (the gateway client retries transport errors with an unbounded exponential backoff), holding RPC tasks and letting a public-network client exhaust the RPC concurrency budget. These requests are now bounded by `--rpc.gateway-trace-timeout` and bail out early on graceful shutdown.
 - Subscriptions are now torn down when their websocket connection closes, instead of when they next try to send.
 
+### Security
+
+- Hardened the feeder-gateway trace fallback path used by `starknet_traceTransaction` and `starknet_traceBlockTransactions` for the mainnet block range where local re-execution is impossible. Any public-network caller can force this path for the affected blocks, so a compromised or byzantine gateway response is untrusted authoritative input. The trace deserialiser now bounds `internal_calls` nesting depth, caps the length of every `Vec<Felt>`/`Vec<Event>`/`Vec<MsgToL1>` field, and rejects unknown fields on `FunctionInvocation`; the trace mapper walks `internal_calls` iteratively instead of recursively (preventing a stack-overflow `SIGSEGV` that escapes the RPC layer's `catch_unwind`); and the resource counters are summed with checked arithmetic instead of `+`/`.unwrap()` (preventing overflow panics). The gateway fallback path is also logged with a `trace_source` marker.
+
 ## [0.23.1] - 2026-08-03
 
 ### Changed

--- a/crates/gateway-types/src/trace.rs
+++ b/crates/gateway-types/src/trace.rs
@@ -16,10 +16,20 @@ use crate::reply::transaction::ExecutionResources;
 /// exhaust memory or the call stack while deserialising.
 ///
 /// Maximum nesting depth of [`FunctionInvocation::internal_calls`]. Honest
-/// mainnet traces nest only a handful of levels deep; this ceiling is far above
-/// anything legitimate while still preventing unbounded recursion (which would
-/// overflow the stack and `SIGSEGV`, escaping the RPC layer's `catch_unwind`).
-pub const MAX_TRACE_CALL_DEPTH: usize = 128;
+/// mainnet traces nest only a handful of levels deep, so this ceiling is far
+/// above anything legitimate while still preventing unbounded recursion (which
+/// would overflow the stack and `SIGSEGV`, escaping the RPC layer's
+/// `catch_unwind`).
+///
+/// It is deliberately kept below `serde_json`'s built-in recursion limit of
+/// 128. That limit counts every nested JSON container and a single
+/// `internal_calls` level costs two of them (the array plus the child object),
+/// so `serde_json` aborts at roughly 63 levels on the `from_slice`/`from_str`
+/// paths used in production. A cap at or above that point would never fire:
+/// `serde_json` would bail out first with its own generic recursion error.
+/// Keeping it well below that threshold guarantees our explicit, clearly-worded
+/// cap is the one that triggers.
+pub const MAX_TRACE_CALL_DEPTH: usize = 50;
 
 /// Maximum number of elements accepted in a single `Vec<Felt>` field of a trace
 /// (`calldata`, `result`, event `data`/`keys`, message `payload`,

--- a/crates/gateway-types/src/trace.rs
+++ b/crates/gateway-types/src/trace.rs
@@ -325,8 +325,14 @@ mod tests {
         fn accepts_nesting_up_to_the_depth_cap() {
             // `MAX_TRACE_CALL_DEPTH` counts `internal_calls` levels, so a tree
             // with that many nested children is exactly at the limit.
-            let value = nested_invocation(MAX_TRACE_CALL_DEPTH - 1);
-            serde_json::from_value::<FunctionInvocation>(value)
+            //
+            // Serialise and parse with `from_str` rather than `from_value`: only
+            // the string/slice deserialisers track recursion, so this is the
+            // only way to exercise the same path as the production `from_slice`
+            // deserialisation. The cap sits below serde_json's recursion limit,
+            // so a tree at the cap parses without tripping it.
+            let json = serde_json::to_string(&nested_invocation(MAX_TRACE_CALL_DEPTH - 1)).unwrap();
+            serde_json::from_str::<FunctionInvocation>(&json)
                 .expect("nesting at the cap should be accepted");
             // Deserialisation is a scoped operation: the thread-local depth
             // counter must return to zero afterwards.
@@ -335,8 +341,8 @@ mod tests {
 
         #[test]
         fn rejects_nesting_beyond_the_depth_cap() {
-            let value = nested_invocation(MAX_TRACE_CALL_DEPTH + 5);
-            let err = serde_json::from_value::<FunctionInvocation>(value)
+            let json = serde_json::to_string(&nested_invocation(MAX_TRACE_CALL_DEPTH + 5)).unwrap();
+            let err = serde_json::from_str::<FunctionInvocation>(&json)
                 .expect_err("nesting beyond the cap must be rejected");
             assert!(
                 err.to_string().contains("depth cap"),

--- a/crates/gateway-types/src/trace.rs
+++ b/crates/gateway-types/src/trace.rs
@@ -1,8 +1,136 @@
+use std::cell::Cell;
+use std::marker::PhantomData;
+
 use pathfinder_common::{ContractAddress, TransactionHash};
 use pathfinder_crypto::Felt;
-use serde::Deserialize;
+use serde::de::{Error as _, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
 
 use crate::reply::transaction::ExecutionResources;
+
+/// Traces served from the feeder gateway are an *untrusted, authoritative*
+/// surface: for the mainnet block range where local re-execution is impossible
+/// the RPC layer is hard-wired to fall back to the gateway, so a compromised,
+/// malicious or byzantine gateway can hand us an arbitrarily crafted response.
+/// The constants below bound that surface so a single crafted response cannot
+/// exhaust memory or the call stack while deserialising.
+///
+/// Maximum nesting depth of [`FunctionInvocation::internal_calls`]. Honest
+/// mainnet traces nest only a handful of levels deep; this ceiling is far above
+/// anything legitimate while still preventing unbounded recursion (which would
+/// overflow the stack and `SIGSEGV`, escaping the RPC layer's `catch_unwind`).
+pub const MAX_TRACE_CALL_DEPTH: usize = 128;
+
+/// Maximum number of elements accepted in a single `Vec<Felt>` field of a trace
+/// (`calldata`, `result`, event `data`/`keys`, message `payload`,
+/// transaction `signature`). Bounds per-field allocation.
+pub const MAX_TRACE_FELT_COUNT: usize = 1_000_000;
+
+/// Maximum number of items accepted in a single collection field of a trace
+/// (`internal_calls`, `events`, `messages`) at one nesting level.
+pub const MAX_TRACE_ITEM_COUNT: usize = 1_000_000;
+
+thread_local! {
+    /// Current `internal_calls` nesting depth while deserialising a trace.
+    /// Reset to zero once each top-level field has been fully parsed because
+    /// every increment is paired with a [`DepthGuard`] that decrements on drop.
+    static CALL_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Increments the thread-local [`CALL_DEPTH`] on construction and decrements it
+/// on drop, so the counter is restored even if deserialisation fails part-way
+/// through a nested subtree.
+struct DepthGuard;
+
+impl DepthGuard {
+    /// Enters one `internal_calls` nesting level, returning the guard and the
+    /// new depth, or an error if the configured ceiling would be exceeded.
+    fn enter<E: serde::de::Error>() -> Result<Self, E> {
+        let depth = CALL_DEPTH.with(|c| {
+            let depth = c.get() + 1;
+            c.set(depth);
+            depth
+        });
+        let guard = Self;
+        if depth > MAX_TRACE_CALL_DEPTH {
+            return Err(E::custom(format!(
+                "trace call nesting exceeds depth cap of {MAX_TRACE_CALL_DEPTH}"
+            )));
+        }
+        Ok(guard)
+    }
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        CALL_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+    }
+}
+
+/// Deserialises a sequence while rejecting anything longer than `cap` elements,
+/// bounding the pre-allocation to `cap` so a malicious length hint cannot force
+/// a large allocation up front.
+fn deserialize_capped_seq<'de, D, T>(deserializer: D, cap: usize) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct CapVisitor<T> {
+        cap: usize,
+        _marker: PhantomData<T>,
+    }
+
+    impl<'de, T: Deserialize<'de>> Visitor<'de> for CapVisitor<T> {
+        type Value = Vec<T>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "a sequence of at most {} elements", self.cap)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0).min(self.cap));
+            while let Some(element) = seq.next_element()? {
+                if out.len() >= self.cap {
+                    return Err(A::Error::custom(format!(
+                        "trace sequence exceeds cap of {}",
+                        self.cap
+                    )));
+                }
+                out.push(element);
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_seq(CapVisitor {
+        cap,
+        _marker: PhantomData,
+    })
+}
+
+/// [`deserialize_capped_seq`] specialised for `Vec<Felt>` fields.
+fn capped_felts<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Felt>, D::Error> {
+    deserialize_capped_seq(deserializer, MAX_TRACE_FELT_COUNT)
+}
+
+/// [`deserialize_capped_seq`] specialised for `Vec<Event>` fields.
+fn capped_events<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Event>, D::Error> {
+    deserialize_capped_seq(deserializer, MAX_TRACE_ITEM_COUNT)
+}
+
+/// [`deserialize_capped_seq`] specialised for `Vec<MsgToL1>` fields.
+fn capped_messages<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<MsgToL1>, D::Error> {
+    deserialize_capped_seq(deserializer, MAX_TRACE_ITEM_COUNT)
+}
+
+/// Deserialises the recursive `internal_calls` field. Each level enters one
+/// nesting frame (bounding recursion via [`DepthGuard`]) and caps the fan-out.
+fn capped_internal_calls<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<FunctionInvocation>, D::Error> {
+    let _guard = DepthGuard::enter::<D::Error>()?;
+    deserialize_capped_seq(deserializer, MAX_TRACE_ITEM_COUNT)
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -11,6 +139,7 @@ pub struct TransactionTrace {
     pub validate_invocation: Option<FunctionInvocation>,
     pub function_invocation: Option<FunctionInvocation>,
     pub fee_transfer_invocation: Option<FunctionInvocation>,
+    #[serde(deserialize_with = "capped_felts")]
     pub signature: Vec<Felt>,
     // This is present for get_block_traces but not for an individual transaction's
     // trace in get_transaction_trace.
@@ -35,13 +164,17 @@ pub enum CallType {
 #[serde(deny_unknown_fields)]
 pub struct Event {
     pub order: i64,
+    #[serde(deserialize_with = "capped_felts")]
     pub data: Vec<Felt>,
+    #[serde(deserialize_with = "capped_felts")]
     pub keys: Vec<Felt>,
 }
 
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FunctionInvocation {
+    #[serde(deserialize_with = "capped_felts")]
     pub calldata: Vec<Felt>,
     pub contract_address: ContractAddress,
     #[serde(default)]
@@ -50,17 +183,17 @@ pub struct FunctionInvocation {
     pub call_type: Option<CallType>,
     #[serde(default)]
     pub caller_address: Felt,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "capped_internal_calls")]
     pub internal_calls: Vec<FunctionInvocation>,
     #[serde(default)]
     pub class_hash: Option<Felt>,
     #[serde(default)]
     pub entry_point_type: Option<EntryPointType>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "capped_events")]
     pub events: Vec<Event>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "capped_messages")]
     pub messages: Vec<MsgToL1>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "capped_felts")]
     pub result: Vec<Felt>,
     pub execution_resources: ExecutionResources,
     #[serde(default)]
@@ -85,6 +218,7 @@ pub enum EntryPointType {
 #[serde(deny_unknown_fields)]
 pub struct MsgToL1 {
     pub order: usize,
+    #[serde(deserialize_with = "capped_felts")]
     pub payload: Vec<Felt>,
     pub to_address: Felt,
 }
@@ -139,6 +273,109 @@ mod tests {
         #[test]
         fn parse_0x6a4a() {
             serde_json::from_slice::<TransactionTrace>(SEPOLIA_TESTNET_TX_0X6A4A).unwrap();
+        }
+    }
+
+    mod hardening {
+        use serde_json::json;
+
+        use super::*;
+
+        /// Builds a minimal, valid `FunctionInvocation` JSON object with
+        /// `internal_calls` nested `depth` levels deep.
+        fn nested_invocation(depth: usize) -> serde_json::Value {
+            let execution_resources = json!({
+                "builtin_instance_counter": {},
+                "n_steps": 0,
+                "n_memory_holes": 0,
+            });
+            let mut node = json!({
+                "calldata": [],
+                "contract_address": "0x1",
+                "execution_resources": execution_resources,
+                "internal_calls": [],
+            });
+            for _ in 0..depth {
+                let child = node;
+                node = json!({
+                    "calldata": [],
+                    "contract_address": "0x1",
+                    "execution_resources": {
+                        "builtin_instance_counter": {},
+                        "n_steps": 0,
+                        "n_memory_holes": 0,
+                    },
+                    "internal_calls": [child],
+                });
+            }
+            node
+        }
+
+        #[test]
+        fn accepts_nesting_up_to_the_depth_cap() {
+            // `MAX_TRACE_CALL_DEPTH` counts `internal_calls` levels, so a tree
+            // with that many nested children is exactly at the limit.
+            let value = nested_invocation(MAX_TRACE_CALL_DEPTH - 1);
+            serde_json::from_value::<FunctionInvocation>(value)
+                .expect("nesting at the cap should be accepted");
+            // Deserialisation is a scoped operation: the thread-local depth
+            // counter must return to zero afterwards.
+            assert_eq!(CALL_DEPTH.with(|c| c.get()), 0);
+        }
+
+        #[test]
+        fn rejects_nesting_beyond_the_depth_cap() {
+            let value = nested_invocation(MAX_TRACE_CALL_DEPTH + 5);
+            let err = serde_json::from_value::<FunctionInvocation>(value)
+                .expect_err("nesting beyond the cap must be rejected");
+            assert!(
+                err.to_string().contains("depth cap"),
+                "unexpected error: {err}"
+            );
+            assert_eq!(CALL_DEPTH.with(|c| c.get()), 0);
+        }
+
+        #[test]
+        fn rejects_unknown_fields_on_function_invocation() {
+            let value = json!({
+                "calldata": [],
+                "contract_address": "0x1",
+                "execution_resources": {
+                    "builtin_instance_counter": {},
+                    "n_steps": 0,
+                    "n_memory_holes": 0,
+                },
+                "surprise": "field",
+            });
+            let err = serde_json::from_value::<FunctionInvocation>(value)
+                .expect_err("unknown fields must be rejected");
+            assert!(
+                err.to_string().contains("unknown field"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_overlong_felt_vectors() {
+            // One past the cap in a `Vec<Felt>` field must be rejected without
+            // materialising the whole sequence.
+            let calldata: Vec<serde_json::Value> =
+                (0..=MAX_TRACE_FELT_COUNT).map(|_| json!("0x1")).collect();
+            let value = json!({
+                "calldata": calldata,
+                "contract_address": "0x1",
+                "execution_resources": {
+                    "builtin_instance_counter": {},
+                    "n_steps": 0,
+                    "n_memory_holes": 0,
+                },
+            });
+            let err = serde_json::from_value::<FunctionInvocation>(value)
+                .expect_err("overlong calldata must be rejected");
+            assert!(
+                err.to_string().contains("exceeds cap"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -240,6 +240,16 @@ pub async fn trace_block_transactions(
         LocalExecution::Unsupported((block_id, transactions)) => (block_id, transactions),
     };
 
+    // Mark the fallback path so operators can tell which trace responses were
+    // sourced from the (untrusted, authoritative) feeder gateway rather than
+    // produced by local re-execution. On the wire this is already observable to
+    // callers as an absence of state diffs / `initial_reads`.
+    tracing::debug!(
+        trace_source = "feeder_gateway",
+        ?block_id,
+        "Serving block traces from the feeder gateway fallback path"
+    );
+
     // The gateway client retries transport errors with an unbounded exponential
     // backoff, so a slow or unresponsive sequencer would otherwise hold this task
     // (and the resources acquired during the preflight) for the full retry
@@ -310,130 +320,95 @@ pub(crate) fn map_gateway_trace(
         .map(|i| (i.execution_resources, i.gas_consumed))
         .unwrap_or_default();
 
+    // The gateway trace is untrusted authoritative input on the mainnet
+    // fallback path, so these counters are attacker-controlled. Sum them with
+    // `checked_add` and convert with `try_from` rather than `+` / `.unwrap()`,
+    // turning an overflow into a typed error instead of a panic (or a silently
+    // wrapped value in release builds).
+    let sum =
+        |select: fn(&starknet_gateway_types::reply::transaction::ExecutionResources) -> u64,
+         field: &str|
+         -> anyhow::Result<usize> {
+            sum3_to_usize(
+                [
+                    select(&validate_invocation_resources),
+                    select(&function_invocation_resources),
+                    select(&fee_transfer_invocation_resources),
+                ],
+                field,
+            )
+        };
     let computation_resources = pathfinder_executor::types::ComputationResources {
-        steps: (validate_invocation_resources.n_steps
-            + function_invocation_resources.n_steps
-            + fee_transfer_invocation_resources.n_steps)
-            .try_into()
-            .unwrap(),
-        memory_holes: (validate_invocation_resources.n_memory_holes
-            + function_invocation_resources.n_memory_holes
-            + fee_transfer_invocation_resources.n_memory_holes)
-            .try_into()
-            .unwrap(),
-        range_check_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .range_check_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .range_check_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .range_check_builtin)
-            .try_into()
-            .unwrap(),
-        pedersen_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .pedersen_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .pedersen_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .pedersen_builtin)
-            .try_into()
-            .unwrap(),
-        poseidon_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .poseidon_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .poseidon_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .poseidon_builtin)
-            .try_into()
-            .unwrap(),
-        ec_op_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .ec_op_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .ec_op_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .ec_op_builtin)
-            .try_into()
-            .unwrap(),
-        ecdsa_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .ecdsa_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .ecdsa_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .ecdsa_builtin)
-            .try_into()
-            .unwrap(),
-        bitwise_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .bitwise_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .bitwise_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .bitwise_builtin)
-            .try_into()
-            .unwrap(),
-        keccak_builtin_applications: (validate_invocation_resources
-            .builtin_instance_counter
-            .keccak_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .keccak_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .keccak_builtin)
-            .try_into()
-            .unwrap(),
-        segment_arena_builtin: (validate_invocation_resources
-            .builtin_instance_counter
-            .segment_arena_builtin
-            + function_invocation_resources
-                .builtin_instance_counter
-                .segment_arena_builtin
-            + fee_transfer_invocation_resources
-                .builtin_instance_counter
-                .segment_arena_builtin)
-            .try_into()
-            .unwrap(),
+        steps: sum(|r| r.n_steps, "steps")?,
+        memory_holes: sum(|r| r.n_memory_holes, "memory_holes")?,
+        range_check_builtin_applications: sum(
+            |r| r.builtin_instance_counter.range_check_builtin,
+            "range_check_builtin_applications",
+        )?,
+        pedersen_builtin_applications: sum(
+            |r| r.builtin_instance_counter.pedersen_builtin,
+            "pedersen_builtin_applications",
+        )?,
+        poseidon_builtin_applications: sum(
+            |r| r.builtin_instance_counter.poseidon_builtin,
+            "poseidon_builtin_applications",
+        )?,
+        ec_op_builtin_applications: sum(
+            |r| r.builtin_instance_counter.ec_op_builtin,
+            "ec_op_builtin_applications",
+        )?,
+        ecdsa_builtin_applications: sum(
+            |r| r.builtin_instance_counter.ecdsa_builtin,
+            "ecdsa_builtin_applications",
+        )?,
+        bitwise_builtin_applications: sum(
+            |r| r.builtin_instance_counter.bitwise_builtin,
+            "bitwise_builtin_applications",
+        )?,
+        keccak_builtin_applications: sum(
+            |r| r.builtin_instance_counter.keccak_builtin,
+            "keccak_builtin_applications",
+        )?,
+        segment_arena_builtin: sum(
+            |r| r.builtin_instance_counter.segment_arena_builtin,
+            "segment_arena_builtin",
+        )?,
     };
+    // `saturating_add` for the same reason the counters above use `checked_add`:
+    // these `u128` gas figures are attacker-controlled on the fallback path and
+    // must not panic (debug) or silently wrap (release) on overflow.
     let l1_gas = validate_invocation_resources
         .total_gas_consumed
         .unwrap_or_default()
         .l1_gas
-        + function_invocation_resources
-            .total_gas_consumed
-            .unwrap_or_default()
-            .l1_gas
-        + fee_transfer_invocation_resources
-            .total_gas_consumed
-            .unwrap_or_default()
-            .l1_gas;
+        .saturating_add(
+            function_invocation_resources
+                .total_gas_consumed
+                .unwrap_or_default()
+                .l1_gas,
+        )
+        .saturating_add(
+            fee_transfer_invocation_resources
+                .total_gas_consumed
+                .unwrap_or_default()
+                .l1_gas,
+        );
     let l1_data_gas = validate_invocation_resources
         .total_gas_consumed
         .unwrap_or_default()
         .l1_data_gas
-        + function_invocation_resources
-            .total_gas_consumed
-            .unwrap_or_default()
-            .l1_data_gas
-        + fee_transfer_invocation_resources
-            .total_gas_consumed
-            .unwrap_or_default()
-            .l1_data_gas;
+        .saturating_add(
+            function_invocation_resources
+                .total_gas_consumed
+                .unwrap_or_default()
+                .l1_data_gas,
+        )
+        .saturating_add(
+            fee_transfer_invocation_resources
+                .total_gas_consumed
+                .unwrap_or_default()
+                .l1_data_gas,
+        );
     let validate_invocation_l2_gas = validate_invocation_gas_consumed.unwrap_or_else(|| {
         validate_invocation_resources
             .total_gas_consumed
@@ -455,7 +430,9 @@ pub(crate) fn map_gateway_trace(
             .l2_gas
             .unwrap_or_default()
     });
-    let l2_gas = validate_invocation_l2_gas + function_invocation_l2_gas + fee_transfer_l2_gas;
+    let l2_gas = validate_invocation_l2_gas
+        .saturating_add(function_invocation_l2_gas)
+        .saturating_add(fee_transfer_l2_gas);
     let execution_resources = pathfinder_executor::types::ExecutionResources {
         computation_resources,
         // These values are not available in the gateway trace.
@@ -570,8 +547,78 @@ pub(crate) fn map_gateway_trace(
     })
 }
 
+/// Sums three attacker-controlled `u64` counters from a gateway trace and
+/// converts the total to `usize`, returning a typed error on overflow instead
+/// of panicking (or silently wrapping in release builds).
+fn sum3_to_usize(values: [u64; 3], field: &str) -> anyhow::Result<usize> {
+    let total = values
+        .into_iter()
+        .try_fold(0u64, |acc, value| acc.checked_add(value))
+        .with_context(|| format!("Overflow summing `{field}` in gateway trace"))?;
+    u64_to_usize(total, field)
+}
+
+/// Converts a `u64` counter from a gateway trace to `usize`, returning a typed
+/// error rather than panicking if it does not fit (e.g. on a 32-bit target).
+fn u64_to_usize(value: u64, field: &str) -> anyhow::Result<usize> {
+    usize::try_from(value)
+        .with_context(|| format!("`{field}` exceeds usize range in gateway trace"))
+}
+
 fn map_gateway_function_invocation(
     invocation: starknet_gateway_types::trace::FunctionInvocation,
+) -> anyhow::Result<pathfinder_executor::types::FunctionInvocation> {
+    // Map the invocation tree iteratively (post-order) rather than recursively.
+    // `internal_calls` comes from an untrusted feeder gateway on the mainnet
+    // fallback path; a recursive mapping would overflow the stack (a SIGSEGV
+    // that the RPC layer's `catch_unwind` cannot recover) on a deeply nested
+    // tree. Deserialisation already bounds the nesting depth
+    // (`MAX_TRACE_CALL_DEPTH`), and this explicit work stack keeps the mapping
+    // safe regardless of that bound.
+    struct Frame {
+        node: starknet_gateway_types::trace::FunctionInvocation,
+        remaining: std::vec::IntoIter<starknet_gateway_types::trace::FunctionInvocation>,
+        mapped_children: Vec<pathfinder_executor::types::FunctionInvocation>,
+    }
+
+    fn into_frame(mut node: starknet_gateway_types::trace::FunctionInvocation) -> Frame {
+        let children = std::mem::take(&mut node.internal_calls);
+        Frame {
+            node,
+            remaining: children.into_iter(),
+            mapped_children: Vec::new(),
+        }
+    }
+
+    let mut stack = vec![into_frame(invocation)];
+    let mut completed: Option<pathfinder_executor::types::FunctionInvocation> = None;
+
+    while let Some(frame) = stack.last_mut() {
+        if let Some(child) = completed.take() {
+            frame.mapped_children.push(child);
+        }
+        match frame.remaining.next() {
+            Some(child) => stack.push(into_frame(child)),
+            None => {
+                let frame = stack
+                    .pop()
+                    .expect("frame present: just obtained via last_mut");
+                completed = Some(map_shallow_invocation(frame.node, frame.mapped_children)?);
+            }
+        }
+    }
+
+    Ok(completed.expect("the root frame always yields a mapped invocation"))
+}
+
+/// Maps a single gateway
+/// [`FunctionInvocation`](starknet_gateway_types::trace::FunctionInvocation)
+/// into its executor counterpart, given its already-mapped `internal_calls`.
+/// Contains no recursion; the tree walk lives in
+/// [`map_gateway_function_invocation`].
+fn map_shallow_invocation(
+    invocation: starknet_gateway_types::trace::FunctionInvocation,
+    internal_calls: Vec<pathfinder_executor::types::FunctionInvocation>,
 ) -> anyhow::Result<pathfinder_executor::types::FunctionInvocation> {
     let gas_consumed = invocation
         .execution_resources
@@ -590,11 +637,7 @@ fn map_gateway_function_invocation(
             }
         }),
         caller_address: invocation.caller_address,
-        internal_calls: invocation
-            .internal_calls
-            .into_iter()
-            .map(map_gateway_function_invocation)
-            .collect::<Result<_, _>>()?,
+        internal_calls,
         class_hash: invocation.class_hash,
         entry_point_type: invocation.entry_point_type.map(
             |entry_point_type| match entry_point_type {
@@ -629,7 +672,7 @@ fn map_gateway_function_invocation(
             })
             .collect(),
         result: invocation.result,
-        computation_resources: map_gateway_computation_resources(invocation.execution_resources),
+        computation_resources: map_gateway_computation_resources(invocation.execution_resources)?,
         execution_resources: InnerCallExecutionResources {
             l1_gas: gas_consumed.l1_gas,
             l2_gas: gas_consumed.l2_gas.unwrap_or_default(),
@@ -640,51 +683,44 @@ fn map_gateway_function_invocation(
 
 fn map_gateway_computation_resources(
     resources: starknet_gateway_types::reply::transaction::ExecutionResources,
-) -> pathfinder_executor::types::ComputationResources {
-    pathfinder_executor::types::ComputationResources {
-        steps: resources.n_steps.try_into().unwrap(),
-        memory_holes: resources.n_memory_holes.try_into().unwrap(),
-        range_check_builtin_applications: resources
-            .builtin_instance_counter
-            .range_check_builtin
-            .try_into()
-            .unwrap(),
-        pedersen_builtin_applications: resources
-            .builtin_instance_counter
-            .pedersen_builtin
-            .try_into()
-            .unwrap(),
-        poseidon_builtin_applications: resources
-            .builtin_instance_counter
-            .poseidon_builtin
-            .try_into()
-            .unwrap(),
-        ec_op_builtin_applications: resources
-            .builtin_instance_counter
-            .ec_op_builtin
-            .try_into()
-            .unwrap(),
-        ecdsa_builtin_applications: resources
-            .builtin_instance_counter
-            .ecdsa_builtin
-            .try_into()
-            .unwrap(),
-        bitwise_builtin_applications: resources
-            .builtin_instance_counter
-            .bitwise_builtin
-            .try_into()
-            .unwrap(),
-        keccak_builtin_applications: resources
-            .builtin_instance_counter
-            .keccak_builtin
-            .try_into()
-            .unwrap(),
-        segment_arena_builtin: resources
-            .builtin_instance_counter
-            .segment_arena_builtin
-            .try_into()
-            .unwrap(),
-    }
+) -> anyhow::Result<pathfinder_executor::types::ComputationResources> {
+    let counter = resources.builtin_instance_counter;
+    Ok(pathfinder_executor::types::ComputationResources {
+        steps: u64_to_usize(resources.n_steps, "steps")?,
+        memory_holes: u64_to_usize(resources.n_memory_holes, "memory_holes")?,
+        range_check_builtin_applications: u64_to_usize(
+            counter.range_check_builtin,
+            "range_check_builtin_applications",
+        )?,
+        pedersen_builtin_applications: u64_to_usize(
+            counter.pedersen_builtin,
+            "pedersen_builtin_applications",
+        )?,
+        poseidon_builtin_applications: u64_to_usize(
+            counter.poseidon_builtin,
+            "poseidon_builtin_applications",
+        )?,
+        ec_op_builtin_applications: u64_to_usize(
+            counter.ec_op_builtin,
+            "ec_op_builtin_applications",
+        )?,
+        ecdsa_builtin_applications: u64_to_usize(
+            counter.ecdsa_builtin,
+            "ecdsa_builtin_applications",
+        )?,
+        bitwise_builtin_applications: u64_to_usize(
+            counter.bitwise_builtin,
+            "bitwise_builtin_applications",
+        )?,
+        keccak_builtin_applications: u64_to_usize(
+            counter.keccak_builtin,
+            "keccak_builtin_applications",
+        )?,
+        segment_arena_builtin: u64_to_usize(
+            counter.segment_arena_builtin,
+            "segment_arena_builtin",
+        )?,
+    })
 }
 
 impl crate::dto::SerializeForVersion for TraceBlockTransactionsOutput {
@@ -2018,5 +2054,85 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
+    }
+
+    mod hardening {
+        use starknet_gateway_types::trace::FunctionInvocation as GatewayInvocation;
+
+        use super::super::{map_gateway_function_invocation, sum3_to_usize, u64_to_usize};
+
+        fn leaf_invocation() -> GatewayInvocation {
+            GatewayInvocation {
+                calldata: vec![],
+                contract_address: pathfinder_common::ContractAddress::ZERO,
+                selector: None,
+                call_type: None,
+                caller_address: pathfinder_crypto::Felt::ZERO,
+                internal_calls: vec![],
+                class_hash: None,
+                entry_point_type: None,
+                events: vec![],
+                messages: vec![],
+                result: vec![],
+                execution_resources: Default::default(),
+                failed: false,
+                gas_consumed: None,
+                cairo_native: false,
+            }
+        }
+
+        /// The iterative mapper must preserve `internal_calls` nesting exactly.
+        #[test]
+        fn iterative_mapping_preserves_nesting() {
+            // A linear chain of `internal_calls`, deep enough that a naive
+            // recursion would be visibly deep but shallow enough that dropping
+            // the resulting tree is safe.
+            const DEPTH: usize = 4_000;
+
+            let mut node = leaf_invocation();
+            for _ in 0..DEPTH {
+                let mut parent = leaf_invocation();
+                parent.internal_calls = vec![node];
+                node = parent;
+            }
+
+            let mapped = map_gateway_function_invocation(node).expect("mapping must succeed");
+
+            // Walk the mapped tree and confirm the depth round-trips.
+            let mut count = 0usize;
+            let mut cursor = &mapped;
+            loop {
+                count += 1;
+                match cursor.internal_calls.first() {
+                    Some(child) => cursor = child,
+                    None => break,
+                }
+            }
+            assert_eq!(count, DEPTH + 1);
+        }
+
+        /// A node with several children must map all of them, in order.
+        #[test]
+        fn iterative_mapping_preserves_fan_out() {
+            let mut root = leaf_invocation();
+            root.internal_calls = (0..8).map(|_| leaf_invocation()).collect();
+
+            let mapped = map_gateway_function_invocation(root).expect("mapping must succeed");
+            assert_eq!(mapped.internal_calls.len(), 8);
+        }
+
+        #[test]
+        fn sum3_to_usize_reports_overflow_instead_of_panicking() {
+            let err = sum3_to_usize([u64::MAX, u64::MAX, 1], "steps")
+                .expect_err("overflowing counters must produce an error, not a panic");
+            assert!(err.to_string().contains("Overflow summing"), "{err}");
+
+            assert_eq!(sum3_to_usize([1, 2, 3], "steps").unwrap(), 6);
+        }
+
+        #[test]
+        fn u64_to_usize_round_trips_in_range_values() {
+            assert_eq!(u64_to_usize(42, "steps").unwrap(), 42);
+        }
     }
 }

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -244,6 +244,15 @@ pub async fn trace_transaction(
         LocalExecution::Unsupported(tx) => tx,
     };
 
+    // Mark the fallback path so operators can tell which trace responses were
+    // sourced from the (untrusted, authoritative) feeder gateway rather than
+    // produced by local re-execution.
+    tracing::debug!(
+        trace_source = "feeder_gateway",
+        transaction_hash = %input.transaction_hash,
+        "Serving transaction trace from the feeder gateway fallback path"
+    );
+
     // The gateway client retries transport errors with an unbounded exponential
     // backoff, so a slow or unresponsive sequencer would otherwise hold this task
     // (and the resources acquired during the preflight) for the full retry


### PR DESCRIPTION
The mainnet block range where local re-execution is impossible forces trace_transaction / trace_block_transactions onto the feeder-gateway fallback path, which any public-network caller can trigger for those blocks. On that path the gateway response is untrusted authoritative input, yet it reached the trace deserialiser and mapper without depth caps, width caps, or checked arithmetic.

- Bound `internal_calls` nesting depth and cap every `Vec<Felt>`/`Vec<Event>`/`Vec<MsgToL1>` field during deserialisation, and add `deny_unknown_fields` to `FunctionInvocation`.
- Map `internal_calls` iteratively instead of recursively so a deeply nested tree can no longer overflow the stack (a SIGSEGV that escapes the RPC layer's catch_unwind).
- Sum the resource counters with checked_add / saturating_add and convert with try_from + typed errors instead of `+` / `.unwrap()`.
- Log the fallback path with a `trace_source` marker.