### PR TITLE
fix(rpc): slow gateway blocks DB pool on cold preconfirmed cache

### DIFF
--- a/crates/rpc/src/method/call.rs
+++ b/crates/rpc/src/method/call.rs
@@ -5,6 +5,7 @@ use pathfinder_executor::{ExecutionState, L1BlobDataAvailability};
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
 use crate::executor::CALLDATA_LIMIT;
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -125,6 +126,7 @@ pub async fn call(
             "Calldata limit ({CALLDATA_LIMIT}) exceeded"
         )));
     }
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     let result = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -136,18 +138,18 @@ pub async fn call(
             .transaction()
             .context("Creating database transaction")?;
 
-        let (header, pending) = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db_tx)?;
+        let (header, pending) = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db_tx)?;
 
                 (
                     pending.pre_confirmed_header(),
                     Some(pending.aggregated_state_update()),
                 )
             }
-            other => {
+            UnvalidatedOrId::Other(other) => {
                 let block_id = other
-                    .to_common_or_panic(&db_tx)
+                    .to_common(&db_tx)
                     .map_err(|_| CallError::BlockNotFound)?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/estimate_fee.rs
+++ b/crates/rpc/src/method/estimate_fee.rs
@@ -10,6 +10,7 @@ use crate::executor::{
     CALLDATA_LIMIT,
     SIGNATURE_ELEMENT_LIMIT,
 };
+use crate::pending::UnvalidatedOrId;
 use crate::types::request::BroadcastedTransaction;
 use crate::types::BlockId;
 use crate::RpcVersion;
@@ -69,6 +70,7 @@ pub async fn estimate_fee(
              {bad_tx_idx}"
         )));
     }
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     let result = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -99,18 +101,18 @@ pub async fn estimate_fee(
             .transaction()
             .context("Creating database transaction")?;
 
-        let (header, pending) = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db_tx)?;
+        let (header, pending) = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db_tx)?;
 
                 (
                     pending.pre_confirmed_header(),
                     Some(pending.aggregated_state_update()),
                 )
             }
-            other => {
+            UnvalidatedOrId::Other(other) => {
                 let block_id = other
-                    .to_common_or_panic(&db_tx)
+                    .to_common(&db_tx)
                     .map_err(|_| EstimateFeeError::BlockNotFound)?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/estimate_message_fee.rs
+++ b/crates/rpc/src/method/estimate_message_fee.rs
@@ -10,6 +10,7 @@ use starknet_api::transaction::fields::{Calldata, Fee};
 use crate::context::RpcContext;
 use crate::error::ApplicationError;
 use crate::executor::CALLDATA_LIMIT;
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -66,6 +67,7 @@ pub async fn estimate_message_fee(
             "Calldata limit ({CALLDATA_LIMIT}) exceeded"
         )));
     }
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     let mut result = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db_conn = context
@@ -76,18 +78,18 @@ pub async fn estimate_message_fee(
             .transaction()
             .context("Creating database transaction")?;
 
-        let (header, pending) = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db_tx)?;
+        let (header, pending) = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db_tx)?;
 
                 (
                     pending.pre_confirmed_header(),
                     Some(pending.aggregated_state_update()),
                 )
             }
-            other => {
+            UnvalidatedOrId::Other(other) => {
                 let block_id = other
-                    .to_common_or_panic(&db_tx)
+                    .to_common(&db_tx)
                     .map_err(|_| EstimateMessageFeeError::BlockNotFound)?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/get_block_transaction_count.rs
+++ b/crates/rpc/src/method/get_block_transaction_count.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 
 use crate::context::RpcContext;
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -31,6 +32,7 @@ pub async fn get_block_transaction_count(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = context
@@ -39,19 +41,15 @@ pub async fn get_block_transaction_count(
             .context("Opening database connection")?;
         let db = db.transaction().context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
-                let count = context
-                    .pending_data
-                    .get(&db)?
-                    .pre_confirmed_transactions()
-                    .len() as u64;
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let count = pending.validate(&db)?.pre_confirmed_transactions().len() as u64;
                 return Ok(Output(count));
             }
 
-            other => other
-                .to_common_or_panic(&db)
-                .map_err(|_| Error::BlockNotFound)?,
+            UnvalidatedOrId::Other(other) => {
+                other.to_common(&db).map_err(|_| Error::BlockNotFound)?
+            }
         };
 
         let exists = db

--- a/crates/rpc/src/method/get_block_with_receipts.rs
+++ b/crates/rpc/src/method/get_block_with_receipts.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 
 use crate::context::RpcContext;
 use crate::dto::{TransactionResponseFlags, TxnFinalityStatus};
-use crate::pending::PendingBlocks;
+use crate::pending::{PendingBlocks, UnvalidatedOrId};
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -61,6 +61,7 @@ pub async fn get_block_with_receipts(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -77,18 +78,18 @@ pub async fn get_block_with_receipts(
 
         let db = db.transaction().context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db)?;
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db)?;
 
                 return Ok(Output::Pending {
                     block: pending.pending_block(),
                     include_proof_facts,
                 });
             }
-            other => other
-                .to_common_or_panic(&db)
-                .map_err(|_| Error::BlockNotFound)?,
+            UnvalidatedOrId::Other(other) => {
+                other.to_common(&db).map_err(|_| Error::BlockNotFound)?
+            }
         };
 
         let header = db

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use pathfinder_common::{BlockHeader, TransactionHash};
 
 use crate::context::RpcContext;
-use crate::pending::PendingBlocks;
+use crate::pending::{PendingBlocks, UnvalidatedOrId};
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -44,6 +44,7 @@ pub async fn get_block_with_tx_hashes(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut connection = context
@@ -55,9 +56,9 @@ pub async fn get_block_with_tx_hashes(
             .transaction()
             .context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&transaction)?;
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&transaction)?;
 
                 let transactions = pending
                     .pre_confirmed_transactions()
@@ -70,8 +71,8 @@ pub async fn get_block_with_tx_hashes(
                     transactions,
                 });
             }
-            other => other
-                .to_common_or_panic(&transaction)
+            UnvalidatedOrId::Other(other) => other
+                .to_common(&transaction)
                 .map_err(|_| Error::BlockNotFound)?,
         };
 

--- a/crates/rpc/src/method/get_block_with_tx_hashes.rs
+++ b/crates/rpc/src/method/get_block_with_tx_hashes.rs
@@ -144,6 +144,10 @@ impl crate::dto::SerializeForVersion for Output {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use pathfinder_pending_data::PendingDataCache;
+
     use super::*;
     use crate::dto::{SerializeForVersion, Serializer};
     use crate::RpcVersion;
@@ -214,5 +218,49 @@ mod tests {
             version,
             "blocks/latest_with_tx_hashes.json"
         );
+    }
+
+    /// Prior to splitting `PendingDataCache::get[_optional]` into and async
+    /// `resolve` and sync `validate` all the RPC methods that used preconfirmed
+    /// data would hold the database connection in `spawn_blocking` for the
+    /// entire duration of the cold start timeout that could happen in
+    /// `PendingDataCache::get[_optional]` if the cache was cold and the
+    /// gateway happened to be slow. Using an arbitrary single method is
+    /// representative of all the other affected methods.
+    #[tokio::test]
+    async fn regression_waiting_for_pre_confirmed_data_does_not_hold_a_database_connection() {
+        const COLD_START: Duration = Duration::from_millis(500);
+        const LATEST_TIMEOUT: Duration = Duration::from_millis(300);
+
+        let cache = Arc::new(PendingDataCache::new().with_cold_start_timeout(COLD_START));
+        // Mark stale so that any readers will wait.
+        cache.mark_stale();
+        let context = RpcContext::for_tests().with_pending_data_cache(cache);
+
+        let _waiting = tokio::spawn(get_block_with_tx_hashes(
+            context.clone(),
+            Input {
+                block_id: BlockId::PreConfirmed,
+            },
+            RpcVersion::V09,
+        ));
+
+        // Make sure that the read hangs on waiting for preconfirmed data.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let latest = get_block_with_tx_hashes(
+            context,
+            Input {
+                block_id: BlockId::Latest,
+            },
+            RpcVersion::V09,
+        );
+
+        // Latest should be served regardless of whether the preconfirmed reader is
+        // still waiting.
+        tokio::time::timeout(LATEST_TIMEOUT, latest)
+            .await
+            .unwrap()
+            .unwrap();
     }
 }

--- a/crates/rpc/src/method/get_block_with_txs.rs
+++ b/crates/rpc/src/method/get_block_with_txs.rs
@@ -6,7 +6,7 @@ use pathfinder_common::BlockHeader;
 
 use crate::context::RpcContext;
 use crate::dto::TransactionResponseFlags;
-use crate::pending::PendingBlocks;
+use crate::pending::{PendingBlocks, UnvalidatedOrId};
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -62,6 +62,7 @@ pub async fn get_block_with_txs(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -80,9 +81,9 @@ pub async fn get_block_with_txs(
             .transaction()
             .context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&transaction)?;
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&transaction)?;
 
                 let transactions = pending.pre_confirmed_transactions().to_vec();
 
@@ -92,8 +93,8 @@ pub async fn get_block_with_txs(
                     include_proof_facts,
                 });
             }
-            other => other
-                .to_common_or_panic(&transaction)
+            UnvalidatedOrId::Other(other) => other
+                .to_common(&transaction)
                 .map_err(|_| Error::BlockNotFound)?,
         };
 

--- a/crates/rpc/src/method/get_class.rs
+++ b/crates/rpc/src/method/get_class.rs
@@ -49,6 +49,7 @@ pub async fn get_class(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_by_id(input.block_id).await?;
     let jh = util::task::spawn_blocking(move |_| -> Result<Output, Error> {
         let _g = span.enter();
         let mut db = context
@@ -57,11 +58,10 @@ pub async fn get_class(
             .context("Opening database connection")?;
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let is_pending = input.block_id.is_pending()
-            && context
-                .pending_data
-                .get(&tx)?
-                .class_is_declared(input.class_hash);
+        let is_pending = match pending {
+            Some(pending) => pending.validate(&tx)?.class_is_declared(input.class_hash),
+            None => false,
+        };
 
         let block_id = input
             .block_id

--- a/crates/rpc/src/method/get_class_at.rs
+++ b/crates/rpc/src/method/get_class_at.rs
@@ -58,6 +58,7 @@ pub async fn get_class_at(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_by_id(input.block_id).await?;
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = context
@@ -67,13 +68,11 @@ pub async fn get_class_at(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let pending_class_hash = if input.block_id.is_pending() {
-            context
-                .pending_data
-                .get(&tx)?
-                .find_contract_class(input.contract_address)
-        } else {
-            None
+        let pending_class_hash = match pending {
+            Some(pending) => pending
+                .validate(&tx)?
+                .find_contract_class(input.contract_address),
+            None => None,
         };
 
         let block_id = input

--- a/crates/rpc/src/method/get_class_hash_at.rs
+++ b/crates/rpc/src/method/get_class_hash_at.rs
@@ -33,6 +33,7 @@ pub async fn get_class_hash_at(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_by_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = context
@@ -42,10 +43,9 @@ pub async fn get_class_hash_at(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        if input.block_id.is_pending() {
-            let class_hash = context
-                .pending_data
-                .get(&tx)?
+        if let Some(pending) = pending {
+            let class_hash = pending
+                .validate(&tx)?
                 .find_contract_class(input.contract_address);
 
             if let Some(class_hash) = class_hash {

--- a/crates/rpc/src/method/get_events.rs
+++ b/crates/rpc/src/method/get_events.rs
@@ -172,6 +172,15 @@ pub async fn get_events(
         request.keys.truncate(last_non_empty + 1);
     }
 
+    let requires_pre_confirmed = matches!(request.from_block, Some(PreConfirmed))
+        || matches!(request.to_block, Some(PreConfirmed));
+
+    let pending = if requires_pre_confirmed {
+        Some(context.pending_data.resolve().await?)
+    } else {
+        context.pending_data.resolve_optional().await?
+    };
+
     // blocking task to perform database event query
     let span = tracing::Span::current();
     let db_events: JoinHandle<Result<_, GetEventsError>> = util::task::spawn_blocking(move |_| {
@@ -184,15 +193,7 @@ pub async fn get_events(
             .transaction()
             .context("Creating database transaction")?;
 
-        let requires_pre_confirmed = matches!(request.from_block, Some(PreConfirmed))
-            || matches!(request.to_block, Some(PreConfirmed));
-
-        // Missing pending data only errs when the request explicitly asked for it.
-        let pending: Option<PendingData> = if requires_pre_confirmed {
-            Some(context.pending_data.get(&transaction)?)
-        } else {
-            context.pending_data.get_optional(&transaction)?
-        };
+        let pending: Option<PendingData> = pending.map(|p| p.validate(&transaction)).transpose()?;
 
         // Replace from/to blocks with `BlockId::PreConfirmed` if their numbers match
         // the pre-latest/pre-confirmed block number.

--- a/crates/rpc/src/method/get_nonce.rs
+++ b/crates/rpc/src/method/get_nonce.rs
@@ -33,6 +33,7 @@ pub async fn get_nonce(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_by_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| -> Result<_, Error> {
         let _g = span.enter();
         let mut db = context
@@ -41,11 +42,8 @@ pub async fn get_nonce(
             .context("Opening database connection")?;
         let tx = db.transaction().context("Creating database transaction")?;
 
-        if input.block_id.is_pending() {
-            let nonce = context
-                .pending_data
-                .get(&tx)?
-                .find_nonce(input.contract_address);
+        if let Some(pending) = pending {
+            let nonce = pending.validate(&tx)?.find_nonce(input.contract_address);
 
             if let Some(nonce) = nonce {
                 return Ok(Output(nonce));

--- a/crates/rpc/src/method/get_state_update.rs
+++ b/crates/rpc/src/method/get_state_update.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use pathfinder_common::{ContractAddress, StateUpdate};
 
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::{dto, RpcContext, RpcVersion};
 
@@ -59,6 +60,7 @@ pub async fn get_state_update(
 ) -> Result<Output, Error> {
     let storage = context.storage.clone();
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = storage
@@ -67,20 +69,20 @@ pub async fn get_state_update(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        if input.block_id.is_pending() {
-            let mut state_update = context.pending_data.get(&tx)?.pre_confirmed_state_update();
-            if !input.contract_addresses.is_empty() {
-                let mut own_state_update = state_update.as_ref().clone();
-                filter_state_update_contracts(&mut own_state_update, &input.contract_addresses);
-                state_update = Arc::new(own_state_update);
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let mut state_update = pending.validate(&tx)?.pre_confirmed_state_update();
+                if !input.contract_addresses.is_empty() {
+                    let mut own_state_update = state_update.as_ref().clone();
+                    filter_state_update_contracts(&mut own_state_update, &input.contract_addresses);
+                    state_update = Arc::new(own_state_update);
+                }
+                return Ok(Output::Pending(state_update));
             }
-            return Ok(Output::Pending(state_update));
-        }
-
-        let block_id = input
-            .block_id
-            .to_common_or_panic(&tx)
-            .map_err(|_| Error::BlockNotFound)?;
+            UnvalidatedOrId::Other(block_id) => {
+                block_id.to_common(&tx).map_err(|_| Error::BlockNotFound)?
+            }
+        };
 
         let Some(block_number) = tx.block_number(block_id).context("Fetching block number")? else {
             return Err(Error::BlockNotFound);

--- a/crates/rpc/src/method/get_storage_at.rs
+++ b/crates/rpc/src/method/get_storage_at.rs
@@ -60,6 +60,7 @@ pub async fn get_storage_at(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_by_id(input.block_id).await?;
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -76,8 +77,8 @@ pub async fn get_storage_at(
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        if input.block_id.is_pending() {
-            let pending_data = context.pending_data.get(&tx)?;
+        if let Some(pending) = pending {
+            let pending_data = pending.validate(&tx)?;
             let opt_found = pending_data.find_storage_value(input.contract_address, input.key);
             if let Some(found) = opt_found {
                 let (value, last_update_block) = match found {

--- a/crates/rpc/src/method/get_storage_proof.rs
+++ b/crates/rpc/src/method/get_storage_proof.rs
@@ -10,6 +10,7 @@ use pathfinder_storage::Transaction;
 
 use crate::context::RpcContext;
 use crate::dto::{DeserializeForVersion, SerializeForVersion};
+use crate::types::request::PreconfirmedOrOtherId;
 use crate::types::BlockId;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -288,14 +289,14 @@ pub async fn get_storage_proof(context: RpcContext, input: Input) -> Result<Outp
 
         let tx = db.transaction().context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
+        let block_id = match input.block_id.to_preconfirmed_or_other() {
+            PreconfirmedOrOtherId::PreConfirmed => {
                 // Getting proof of a pre-confirmed block is not supported.
                 return Err(Error::ProofMissing);
             }
-            other => other
-                .to_common_or_panic(&tx)
-                .map_err(|_| Error::BlockNotFound)?,
+            PreconfirmedOrOtherId::Other(other) => {
+                other.to_common(&tx).map_err(|_| Error::BlockNotFound)?
+            }
         };
 
         // Use internal error to indicate that the process of querying for a particular

--- a/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
+++ b/crates/rpc/src/method/get_transaction_by_block_id_and_index.rs
@@ -4,6 +4,7 @@ use pathfinder_common::TransactionIndex;
 
 use crate::context::RpcContext;
 use crate::dto::TransactionResponseFlags;
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::RpcVersion;
 
@@ -68,6 +69,7 @@ pub async fn get_transaction_by_block_id_and_index(
 
     let storage = context.storage.clone();
     let span = tracing::Span::current();
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -77,11 +79,10 @@ pub async fn get_transaction_by_block_id_and_index(
 
         let db_tx = db.transaction().context("Creating database transaction")?;
 
-        let block_id = match input.block_id {
-            BlockId::PreConfirmed => {
-                let result = context
-                    .pending_data
-                    .get(&db_tx)?
+        let block_id = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let result = pending
+                    .validate(&db_tx)?
                     .pre_confirmed_transactions()
                     .get(index)
                     .cloned()
@@ -91,8 +92,8 @@ pub async fn get_transaction_by_block_id_and_index(
                     include_proof_facts,
                 });
             }
-            other => other
-                .to_common_or_panic(&db_tx)
+            UnvalidatedOrId::Other(other) => other
+                .to_common(&db_tx)
                 .map_err(|_| GetTransactionByBlockIdAndIndexError::BlockNotFound)?,
         };
 

--- a/crates/rpc/src/method/get_transaction_by_hash.rs
+++ b/crates/rpc/src/method/get_transaction_by_hash.rs
@@ -55,6 +55,7 @@ pub async fn get_transaction_by_hash(
 
     let storage = context.storage.clone();
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_optional().await?;
     let jh = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = storage
@@ -64,7 +65,7 @@ pub async fn get_transaction_by_hash(
         let db_tx = db.transaction().context("Creating database transaction")?;
 
         // Pending is an optional first look; a finalized tx lives in the DB regardless.
-        let pending = context.pending_data.get_optional(&db_tx)?;
+        let pending = pending.map(|p| p.validate(&db_tx)).transpose()?;
         if let Some(transaction) = pending
             .as_ref()
             .and_then(|p| p.find_transaction(input.transaction_hash))

--- a/crates/rpc/src/method/get_transaction_receipt.rs
+++ b/crates/rpc/src/method/get_transaction_receipt.rs
@@ -88,6 +88,7 @@ pub async fn get_transaction_receipt(
     _rpc_version: RpcVersion,
 ) -> Result<Output, Error> {
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_optional().await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
         let mut db = context
@@ -98,7 +99,7 @@ pub async fn get_transaction_receipt(
         let db_tx = db.transaction().context("Creating database transaction")?;
 
         // Pending is an optional first look; a finalized tx lives in the DB regardless.
-        let pending = context.pending_data.get_optional(&db_tx)?;
+        let pending = pending.map(|p| p.validate(&db_tx)).transpose()?;
 
         let finalized_tx_data = pending
             .as_ref()

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -43,6 +43,7 @@ pub async fn get_transaction_status(
 ) -> Result<Output, Error> {
     // Check database.
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_optional().await?;
     let db_status = util::task::spawn_blocking(move |_| -> Result<Option<Output>, Error> {
         let _g = span.enter();
 
@@ -52,7 +53,7 @@ pub async fn get_transaction_status(
             .context("Opening database connection")?;
         let db_tx = db.transaction().context("Creating database transaction")?;
 
-        let pending_data = context.pending_data.get_optional(&db_tx)?;
+        let pending_data = pending.map(|p| p.validate(&db_tx)).transpose()?;
 
         let finalized_tx_data = pending_data
             .as_ref()

--- a/crates/rpc/src/method/simulate_transactions.rs
+++ b/crates/rpc/src/method/simulate_transactions.rs
@@ -9,6 +9,7 @@ use crate::executor::{
     CALLDATA_LIMIT,
     SIGNATURE_ELEMENT_LIMIT,
 };
+use crate::pending::UnvalidatedOrId;
 use crate::types::request::BroadcastedTransaction;
 use crate::types::BlockId;
 use crate::RpcVersion;
@@ -61,6 +62,7 @@ pub async fn simulate_transactions(
              {bad_tx_idx}"
         )));
     }
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
     util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
@@ -96,18 +98,18 @@ pub async fn simulate_transactions(
             .transaction()
             .context("Creating database transaction")?;
 
-        let (header, pending) = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db_tx)?;
+        let (header, pending) = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db_tx)?;
 
                 (
                     pending.pre_confirmed_header(),
                     Some(pending.aggregated_state_update()),
                 )
             }
-            other => {
+            UnvalidatedOrId::Other(other) => {
                 let block_id = other
-                    .to_common_or_panic(&db_tx)
+                    .to_common(&db_tx)
                     .map_err(|_| SimulateTransactionError::BlockNotFound)?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/trace_block_transactions.rs
+++ b/crates/rpc/src/method/trace_block_transactions.rs
@@ -12,6 +12,7 @@ use crate::executor::{
     MAINNET_RANGE_WHERE_RE_EXECUTION_IS_IMPOSSIBLE_START,
     VERSIONS_LOWER_THAN_THIS_SHOULD_FALL_BACK_TO_FETCHING_TRACE_FROM_GATEWAY,
 };
+use crate::pending::UnvalidatedOrId;
 use crate::types::BlockId;
 use crate::{compose_executor_transaction, RpcVersion};
 
@@ -98,15 +99,17 @@ pub async fn trace_block_transactions(
         .trace_flags
         .contains(&crate::dto::TraceFlag::ReturnInitialReads);
 
+    let pending_or_id = context.pending_data.resolve_or_id(input.block_id).await?;
+
     let traces = util::task::spawn_blocking(move |_| {
         let _g = span.enter();
 
         let mut db_conn = storage.connection()?;
         let db_tx = db_conn.transaction()?;
 
-        let (block_id, header, transactions, pending_state, cache) = match input.block_id {
-            BlockId::PreConfirmed => {
-                let pending = context.pending_data.get(&db_tx)?;
+        let (block_id, header, transactions, pending_state, cache) = match pending_or_id {
+            UnvalidatedOrId::PreConfirmed(pending) => {
+                let pending = pending.validate(&db_tx)?;
 
                 let header = pending.pre_confirmed_header();
                 let transactions = pending.pre_confirmed_transactions().to_vec();
@@ -130,9 +133,9 @@ pub async fn trace_block_transactions(
                     pathfinder_executor::TraceCache::default(),
                 )
             }
-            other => {
+            UnvalidatedOrId::Other(other) => {
                 let block_id = other
-                    .to_common_or_panic(&db_tx)
+                    .to_common(&db_tx)
                     .map_err(|_| TraceBlockTransactionsError::BlockNotFound)?;
 
                 let header = db_tx

--- a/crates/rpc/src/method/trace_transaction.rs
+++ b/crates/rpc/src/method/trace_transaction.rs
@@ -57,6 +57,7 @@ pub async fn trace_transaction(
     }
 
     let span = tracing::Span::current();
+    let pending = context.pending_data.resolve_optional().await?;
     let local =
         util::task::spawn_blocking(move |_| -> Result<LocalExecution, TraceTransactionError> {
             let _g = span.enter();
@@ -70,7 +71,7 @@ pub async fn trace_transaction(
                 .context("Creating database transaction")?;
 
             // Find the transaction's block.
-            let pending = context.pending_data.get_optional(&db_tx)?;
+            let pending = pending.map(|p| p.validate(&db_tx)).transpose()?;
             let pending = pending.as_ref();
 
             let (header, transactions, pending_state, cache) = if let Some((pending, pending_tx)) =

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -595,6 +595,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn validate_retains_only_valid_view_if_commit_head_advanced_after_resolve() {
+        let cache = Arc::new(PendingDataCache::new());
+        let uut = PendingWatcher::new(cache.clone());
+
+        let mut storage = pathfinder_storage::StorageBuilder::in_memory()
+            .unwrap()
+            .connection()
+            .unwrap();
+
+        let parent = BlockHeader::builder()
+            .number(BlockNumber::GENESIS + 12)
+            .finalize_with_hash(block_hash_bytes!(b"parent hash"));
+        let latest = parent
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"latest hash"));
+
+        let tx = storage.transaction().unwrap();
+        tx.insert_block_header(&parent).unwrap();
+        tx.insert_block_header(&latest).unwrap();
+
+        // Cache resolves to pre-latest and pre-confirmed
+        cache.store(valid_pre_confirmed_block_with_pre_latest(&latest));
+        let resolved = uut.resolve().await.unwrap();
+
+        // Pre-latest becomes the new commit head
+        let pre_latest = latest
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"pre latest hash"));
+        tx.insert_block_header(&pre_latest).unwrap();
+
+        let result = resolved.validate(&tx).unwrap();
+
+        let overlay = result.aggregated_state_update();
+        // Prelatest block has been swallowed by the advancing committed head
+        assert!(result.pre_latest_block().is_none());
+        assert!(overlay
+            .contract_nonce(contract_address_bytes!(b"pre latest contract address"))
+            .is_none());
+        // But pre-confirmed block still remains in the valid served view
+        assert!(!result.pre_confirmed_transactions().is_empty());
+        assert_eq!(
+            overlay.contract_nonce(contract_address_bytes!(b"contract address")),
+            Some(contract_nonce_bytes!(b"nonce"))
+        );
+        assert_eq!(result.aggregated_lower_bound, pre_latest.number);
+    }
+
+    #[tokio::test]
+    async fn validate_returns_empty_if_commit_head_advanced_past_resolved_tip() {
+        let cache = Arc::new(PendingDataCache::new());
+        let uut = PendingWatcher::new(cache.clone());
+
+        let mut storage = pathfinder_storage::StorageBuilder::in_memory()
+            .unwrap()
+            .connection()
+            .unwrap();
+
+        let parent = BlockHeader::builder()
+            .number(BlockNumber::GENESIS + 12)
+            .finalize_with_hash(block_hash_bytes!(b"parent hash"));
+        let latest = parent
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"latest hash"));
+
+        let tx = storage.transaction().unwrap();
+        tx.insert_block_header(&parent).unwrap();
+        tx.insert_block_header(&latest).unwrap();
+
+        // Cache resolves to pre-confirmed
+        cache.store(valid_pre_confirmed_block(&latest));
+        let resolved = uut.resolve().await.unwrap();
+
+        // Pre-confirmed becomes the new commit head
+        let pre_confirmed = latest
+            .child_builder()
+            .finalize_with_hash(block_hash_bytes!(b"pre confirmed hash"));
+        tx.insert_block_header(&pre_confirmed).unwrap();
+
+        let result = resolved.validate(&tx).unwrap();
+
+        // The entire pre-confirmed view is now swallowed by the committed head
+        pretty_assertions_sorted::assert_eq_sorted!(result, PendingData::empty(&pre_confirmed));
+    }
+
+    #[tokio::test]
     async fn invalid_pending_defaults_to_latest_in_storage() {
         // If the pending data isn't consistent with the latest data in storage,
         // then the result should be an empty block with the gas price, timestamp

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -451,8 +451,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn valid_pre_confirmed() {
+    #[tokio::test]
+    async fn valid_pre_confirmed() {
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());
 
@@ -469,12 +469,12 @@ mod tests {
         let pending = valid_pre_confirmed_block(&latest);
         cache.store(pending.clone());
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
         pretty_assertions_sorted::assert_eq_sorted!(result, pending);
     }
 
-    #[test]
-    fn valid_pre_confirmed_with_pre_latest() {
+    #[tokio::test]
+    async fn valid_pre_confirmed_with_pre_latest() {
         // There are certain intervals where the pre-latest block is still stored in
         // pending data but that same block has already been finalized and received as
         // the new L2 block. This test makes sure that we still provide pending data
@@ -512,7 +512,7 @@ mod tests {
         let pending = valid_pre_confirmed_block_with_pre_latest(&latest);
         cache.store(pending.clone());
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
         pretty_assertions_sorted::assert_eq_sorted!(result, pending);
 
         // Now the pre-latest block (latest + 1) is itself finalized into storage,
@@ -525,7 +525,7 @@ mod tests {
             .finalize_with_hash(block_hash_bytes!(b"child hash"));
         tx.insert_block_header(&child).unwrap();
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
         // We got a non-empty pre-confirmed block..
         assert!(!result.pre_confirmed_transactions().is_empty());
         // ..and we did not receive a pre-latest block.
@@ -551,8 +551,8 @@ mod tests {
         assert_eq!(result.aggregated_lower_bound, latest.number + 1);
     }
 
-    #[test]
-    fn windowed_pre_confirmed_reports_committed_head_as_old_root() {
+    #[tokio::test]
+    async fn windowed_pre_confirmed_reports_committed_head_as_old_root() {
         // With a pre-latest present the window is two blocks deep, so the tip is
         // served through the immediate-parent branch. Its own state update must
         // carry the committed head's state commitment as its old root, otherwise
@@ -582,7 +582,7 @@ mod tests {
         // Window of two: pre-latest at latest + 1, pre-confirmed at latest + 2.
         cache.store(valid_pre_confirmed_block_with_pre_latest(&latest));
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
 
         assert!(
             result.pre_latest_block().is_some(),
@@ -594,8 +594,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn invalid_pending_defaults_to_latest_in_storage() {
+    #[tokio::test]
+    async fn invalid_pending_defaults_to_latest_in_storage() {
         // If the pending data isn't consistent with the latest data in storage,
         // then the result should be an empty block with the gas price, timestamp
         // and hash as parent hash of the latest block in storage.
@@ -628,15 +628,15 @@ mod tests {
         tx.insert_block_header(&parent).unwrap();
         tx.insert_block_header(&latest).unwrap();
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
 
         let expected = PendingData::empty(&latest);
 
         pretty_assertions_sorted::assert_eq_sorted!(result, expected);
     }
 
-    #[test]
-    fn invalid_pre_confirmed_defaults_to_latest_in_storage() {
+    #[tokio::test]
+    async fn invalid_pre_confirmed_defaults_to_latest_in_storage() {
         // If the pending data isn't consistent with the latest data in storage,
         // then the result should be an empty block with the gas price, timestamp
         // and hash as parent hash of the latest block in storage.
@@ -672,15 +672,15 @@ mod tests {
         let pending = valid_pre_confirmed_block(&parent);
         cache.store(pending.clone());
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
 
         let expected = empty_pre_confirmed_block(&latest);
 
         pretty_assertions_sorted::assert_eq_sorted!(result, expected);
     }
 
-    #[test]
-    fn invalid_pre_confirmed_with_pre_latest_defaults_to_latest_in_storage() {
+    #[tokio::test]
+    async fn invalid_pre_confirmed_with_pre_latest_defaults_to_latest_in_storage() {
         // If the pending data isn't consistent with the latest data in storage,
         // then the result should be an empty block with the gas price, timestamp
         // and hash as parent hash of the latest block in storage.
@@ -730,15 +730,15 @@ mod tests {
         let pending = valid_pre_confirmed_block_with_pre_latest(&parent1);
         cache.store(pending.clone());
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
 
         let expected = empty_pre_confirmed_block(&latest);
 
         pretty_assertions_sorted::assert_eq_sorted!(result, expected);
     }
 
-    #[test]
-    fn pre_confirmed_is_not_child_of_pre_latest_defaults_to_latest_in_storage() {
+    #[tokio::test]
+    async fn pre_confirmed_is_not_child_of_pre_latest_defaults_to_latest_in_storage() {
         let cache = Arc::new(PendingDataCache::new());
         let uut = PendingWatcher::new(cache.clone());
 
@@ -769,7 +769,7 @@ mod tests {
         let pending = invalid_pre_confirmed_block_with_pre_latest(&latest);
         cache.store(pending.clone());
 
-        let result = uut.get(&tx).unwrap();
+        let result = uut.resolve().await.unwrap().validate(&tx).unwrap();
 
         let expected = empty_pre_confirmed_block(&latest);
 

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -14,6 +14,9 @@ use pathfinder_pending_data::{PendingDataCache, ReadError};
 use pathfinder_storage::Transaction;
 use tokio::sync::watch::Receiver as WatchReceiver;
 
+use crate::types::request::NonPreConfirmedBlockId;
+use crate::types::BlockId;
+
 /// A finalized transaction along with its receipt, events, status and the block
 /// number it was included in.
 #[derive(Debug)]
@@ -31,6 +34,19 @@ pub struct PendingWatcher {
     cache: Arc<PendingDataCache>,
 }
 
+/// Preconfirmed data as published by the polling loop. Use [`Self::validate`]
+/// to validate it against the committed head.
+pub struct UnvalidatedPendingData(PendingData);
+
+/// Useful pattern in many RPC methods:
+/// - if the request is for the pre-confirmed block, return the cached data,
+/// - otherwise return the other non-preconfirmed block id variant so the caller
+///   can handle it.
+pub enum UnvalidatedOrId {
+    PreConfirmed(UnvalidatedPendingData),
+    Other(NonPreConfirmedBlockId),
+}
+
 impl PendingWatcher {
     pub fn new(cache: Arc<PendingDataCache>) -> Self {
         Self { cache }
@@ -45,17 +61,17 @@ impl PendingWatcher {
     /// is stale.
     ///
     /// The result must be checked against the committed head with
-    /// [`Unvalidated::validate`] before it can be served.
-    pub async fn resolve(&self) -> Result<Unvalidated, ReadError> {
+    /// [`UnvalidatedPendingData::validate`] before it can be served.
+    pub async fn resolve(&self) -> Result<UnvalidatedPendingData, ReadError> {
         match self.cache.try_read() {
-            Some(data) => Ok(Unvalidated(data)),
-            None => Ok(Unvalidated(self.cache.read().await?)),
+            Some(data) => Ok(UnvalidatedPendingData(data)),
+            None => Ok(UnvalidatedPendingData(self.cache.read().await?)),
         }
     }
 
     /// [`Self::resolve`], which returns `None` instead of an error if the cache
     /// is `Unavailable`.
-    pub async fn resolve_optional(&self) -> Result<Option<Unvalidated>, ReadError> {
+    pub async fn resolve_optional(&self) -> Result<Option<UnvalidatedPendingData>, ReadError> {
         match self.resolve().await {
             Ok(data) => Ok(Some(data)),
             Err(ReadError::Unavailable(_)) => Ok(None),
@@ -65,10 +81,10 @@ impl PendingWatcher {
 
     /// Temporary function which will be removed with `get` and `get_optional`
     /// once the refactor is complete.
-    fn resolve_blocking(&self) -> Result<Unvalidated, ReadError> {
+    fn resolve_blocking(&self) -> Result<UnvalidatedPendingData, ReadError> {
         match self.cache.try_read() {
-            Some(data) => Ok(Unvalidated(data)),
-            None => Ok(Unvalidated(
+            Some(data) => Ok(UnvalidatedPendingData(data)),
+            None => Ok(UnvalidatedPendingData(
                 tokio::runtime::Handle::current().block_on(self.cache.read())?,
             )),
         }
@@ -102,17 +118,41 @@ impl PendingWatcher {
         }
     }
 
+    /// [`Self::resolve`] if block id is [`BlockId::PreConfirmed`], otherwise
+    /// return `None`.
+    pub async fn resolve_by_id(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<UnvalidatedPendingData>, ReadError> {
+        Ok(match block_id {
+            BlockId::PreConfirmed => Some(self.resolve().await?),
+            _ => None,
+        })
+    }
+
+    /// [`Self::resolve`] if block id is [`BlockId::PreConfirmed`], otherwise
+    /// return the other block id variant.
+    pub async fn resolve_or_id(&self, block_id: BlockId) -> Result<UnvalidatedOrId, ReadError> {
+        Ok(match block_id {
+            BlockId::PreConfirmed => UnvalidatedOrId::PreConfirmed(self.resolve().await?),
+            BlockId::Number(block_number) => {
+                UnvalidatedOrId::Other(NonPreConfirmedBlockId::Number(block_number))
+            }
+            BlockId::Hash(block_hash) => {
+                UnvalidatedOrId::Other(NonPreConfirmedBlockId::Hash(block_hash))
+            }
+            BlockId::L1Accepted => UnvalidatedOrId::Other(NonPreConfirmedBlockId::L1Accepted),
+            BlockId::Latest => UnvalidatedOrId::Other(NonPreConfirmedBlockId::Latest),
+        })
+    }
+
     #[cfg(test)]
     pub fn get_unchecked(&self) -> PendingData {
         self.cache.subscribe().borrow().clone()
     }
 }
 
-/// Preconfirmed data as published by the polling loop. Use [`Self::validate`]
-/// to validate it against the committed head.
-pub struct Unvalidated(PendingData);
-
-impl Unvalidated {
+impl UnvalidatedPendingData {
     /// Checks the resolved preconfirmed view against the latest block in
     /// storage and adapts it to that head.
     ///

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -79,45 +79,6 @@ impl PendingWatcher {
         }
     }
 
-    /// Temporary function which will be removed with `get` and `get_optional`
-    /// once the refactor is complete.
-    fn resolve_blocking(&self) -> Result<UnvalidatedPendingData, ReadError> {
-        match self.cache.try_read() {
-            Some(data) => Ok(UnvalidatedPendingData(data)),
-            None => Ok(UnvalidatedPendingData(
-                tokio::runtime::Handle::current().block_on(self.cache.read())?,
-            )),
-        }
-    }
-
-    /// Returns [PendingData] which has been validated against the latest block
-    /// available in storage.
-    ///
-    /// Returns an empty block with gas price and timestamp taken from the
-    /// latest block if no valid pending data is available. The block number
-    /// is also incremented.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called from async context.
-    pub fn get(&self, tx: &Transaction<'_>) -> Result<PendingData, ReadError> {
-        self.resolve_blocking()?.validate(tx)
-    }
-
-    /// Returns the pending data, or `None` when the cache is unavailable.
-    /// Unlike [`Self::get`], an `Unavailable` cache is not an error.
-    ///
-    /// #Panics
-    ///
-    /// This function will panic if called from async context.
-    pub fn get_optional(&self, tx: &Transaction<'_>) -> Result<Option<PendingData>, ReadError> {
-        match self.get(tx) {
-            Ok(data) => Ok(Some(data)),
-            Err(ReadError::Unavailable(_)) => Ok(None),
-            Err(e @ ReadError::Internal(_)) => Err(e),
-        }
-    }
-
     /// [`Self::resolve`] if block id is [`BlockId::PreConfirmed`], otherwise
     /// return `None`.
     pub async fn resolve_by_id(

--- a/crates/rpc/src/pending.rs
+++ b/crates/rpc/src/pending.rs
@@ -41,6 +41,39 @@ impl PendingWatcher {
         self.cache.subscribe()
     }
 
+    /// Reads the cached preconfirmed data, awaiting fresh data if the cache
+    /// is stale.
+    ///
+    /// The result must be checked against the committed head with
+    /// [`Unvalidated::validate`] before it can be served.
+    pub async fn resolve(&self) -> Result<Unvalidated, ReadError> {
+        match self.cache.try_read() {
+            Some(data) => Ok(Unvalidated(data)),
+            None => Ok(Unvalidated(self.cache.read().await?)),
+        }
+    }
+
+    /// [`Self::resolve`], which returns `None` instead of an error if the cache
+    /// is `Unavailable`.
+    pub async fn resolve_optional(&self) -> Result<Option<Unvalidated>, ReadError> {
+        match self.resolve().await {
+            Ok(data) => Ok(Some(data)),
+            Err(ReadError::Unavailable(_)) => Ok(None),
+            Err(e @ ReadError::Internal(_)) => Err(e),
+        }
+    }
+
+    /// Temporary function which will be removed with `get` and `get_optional`
+    /// once the refactor is complete.
+    fn resolve_blocking(&self) -> Result<Unvalidated, ReadError> {
+        match self.cache.try_read() {
+            Some(data) => Ok(Unvalidated(data)),
+            None => Ok(Unvalidated(
+                tokio::runtime::Handle::current().block_on(self.cache.read())?,
+            )),
+        }
+    }
+
     /// Returns [PendingData] which has been validated against the latest block
     /// available in storage.
     ///
@@ -52,15 +85,47 @@ impl PendingWatcher {
     ///
     /// This function will panic if called from async context.
     pub fn get(&self, tx: &Transaction<'_>) -> Result<PendingData, ReadError> {
+        self.resolve_blocking()?.validate(tx)
+    }
+
+    /// Returns the pending data, or `None` when the cache is unavailable.
+    /// Unlike [`Self::get`], an `Unavailable` cache is not an error.
+    ///
+    /// #Panics
+    ///
+    /// This function will panic if called from async context.
+    pub fn get_optional(&self, tx: &Transaction<'_>) -> Result<Option<PendingData>, ReadError> {
+        match self.get(tx) {
+            Ok(data) => Ok(Some(data)),
+            Err(ReadError::Unavailable(_)) => Ok(None),
+            Err(e @ ReadError::Internal(_)) => Err(e),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_unchecked(&self) -> PendingData {
+        self.cache.subscribe().borrow().clone()
+    }
+}
+
+/// Preconfirmed data as published by the polling loop. Use [`Self::validate`]
+/// to validate it against the committed head.
+pub struct Unvalidated(PendingData);
+
+impl Unvalidated {
+    /// Checks the resolved preconfirmed view against the latest block in
+    /// storage and adapts it to that head.
+    ///
+    /// Returns an empty block with gas price and timestamp taken from the
+    /// latest block if no valid pending data is available. The block number
+    /// is also incremented.
+    pub fn validate(self, tx: &Transaction<'_>) -> Result<PendingData, ReadError> {
+        let Self(watched_pending_data) = self;
+
         let latest = tx
             .block_header(pathfinder_common::BlockId::Latest)
             .context("Querying latest block header")?
             .unwrap_or_default();
-
-        let watched_pending_data = match self.cache.try_read() {
-            Some(data) => data,
-            None => tokio::runtime::Handle::current().block_on(self.cache.read())?,
-        };
 
         let watched_pending_blocks = watched_pending_data.pending_block();
         let PendingBlocks {
@@ -182,25 +247,6 @@ impl PendingWatcher {
         };
 
         Ok(pending_data)
-    }
-
-    /// Returns the pending data, or `None` when the cache is unavailable.
-    /// Unlike [`Self::get`], an `Unavailable` cache is not an error.
-    ///
-    /// #Panics
-    ///
-    /// This function will panic if called from async context.
-    pub fn get_optional(&self, tx: &Transaction<'_>) -> Result<Option<PendingData>, ReadError> {
-        match self.get(tx) {
-            Ok(data) => Ok(Some(data)),
-            Err(ReadError::Unavailable(_)) => Ok(None),
-            Err(e @ ReadError::Internal(_)) => Err(e),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn get_unchecked(&self) -> PendingData {
-        self.cache.subscribe().borrow().clone()
     }
 }
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -26,6 +26,24 @@ pub mod request {
         PreConfirmed,
     }
 
+    /// A way of distinguishing between a pre-confirmed and other block
+    /// identifiers.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum PreconfirmedOrOtherId {
+        PreConfirmed,
+        Other(NonPreConfirmedBlockId),
+    }
+
+    /// A way of identifying a block in a JSON-RPC request that **is not the
+    /// pre-confirmed block**.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum NonPreConfirmedBlockId {
+        Number(BlockNumber),
+        Hash(BlockHash),
+        L1Accepted,
+        Latest,
+    }
+
     impl From<BlockHash> for BlockId {
         fn from(value: BlockHash) -> Self {
             BlockId::Hash(value)
@@ -41,35 +59,6 @@ pub mod request {
     impl BlockId {
         pub fn is_pending(&self) -> bool {
             matches!(self, BlockId::PreConfirmed)
-        }
-
-        /// Converts this [BlockId] to a [pathfinder_common::BlockId].
-        ///
-        /// Resolves [`BlockId::L1Accepted`] to the latest L1 accepted block
-        /// number. Returns an error if there is no L1 accepted block number
-        /// or the database lookup fails.
-        ///
-        /// # Panics
-        ///
-        /// If this [BlockId] is [`BlockId::PreConfirmed`].
-        pub fn to_common_or_panic(
-            self,
-            tx: &pathfinder_storage::Transaction<'_>,
-        ) -> anyhow::Result<pathfinder_common::BlockId> {
-            match self {
-                BlockId::Number(number) => Ok(pathfinder_common::BlockId::Number(number)),
-                BlockId::Hash(hash) => Ok(pathfinder_common::BlockId::Hash(hash)),
-                BlockId::L1Accepted => {
-                    let block_number = tx
-                        .l1_l2_pointer()?
-                        .context("L1 accepted block number not found")?;
-                    Ok(pathfinder_common::BlockId::Number(block_number))
-                }
-                BlockId::Latest => Ok(pathfinder_common::BlockId::Latest),
-                BlockId::PreConfirmed => {
-                    panic!("Cannot convert BlockId::PreConfirmed to FinalizedBlockId")
-                }
-            }
         }
 
         /// Converts this [BlockId] to a [pathfinder_common::BlockId].
@@ -94,6 +83,47 @@ pub mod request {
                     Ok(pathfinder_common::BlockId::Number(block_number))
                 }
                 BlockId::Latest | BlockId::PreConfirmed => Ok(pathfinder_common::BlockId::Latest),
+            }
+        }
+
+        pub fn to_preconfirmed_or_other(self) -> PreconfirmedOrOtherId {
+            match self {
+                BlockId::PreConfirmed => PreconfirmedOrOtherId::PreConfirmed,
+                BlockId::Number(number) => {
+                    PreconfirmedOrOtherId::Other(NonPreConfirmedBlockId::Number(number))
+                }
+                BlockId::Hash(hash) => {
+                    PreconfirmedOrOtherId::Other(NonPreConfirmedBlockId::Hash(hash))
+                }
+                BlockId::L1Accepted => {
+                    PreconfirmedOrOtherId::Other(NonPreConfirmedBlockId::L1Accepted)
+                }
+                BlockId::Latest => PreconfirmedOrOtherId::Other(NonPreConfirmedBlockId::Latest),
+            }
+        }
+    }
+
+    impl NonPreConfirmedBlockId {
+        /// Converts this [NonPreConfirmedBlockId] to a
+        /// [pathfinder_common::BlockId].
+        ///
+        /// Resolves [`NonPreConfirmedBlockId::L1Accepted`] to the latest L1
+        /// accepted block number. Returns an error if there is no L1
+        /// accepted block number or the database lookup fails.
+        pub fn to_common(
+            self,
+            tx: &pathfinder_storage::Transaction<'_>,
+        ) -> anyhow::Result<pathfinder_common::BlockId> {
+            match self {
+                Self::Number(number) => Ok(pathfinder_common::BlockId::Number(number)),
+                Self::Hash(hash) => Ok(pathfinder_common::BlockId::Hash(hash)),
+                Self::L1Accepted => {
+                    let block_number = tx
+                        .l1_l2_pointer()?
+                        .context("L1 accepted block number not found")?;
+                    Ok(pathfinder_common::BlockId::Number(block_number))
+                }
+                Self::Latest => Ok(pathfinder_common::BlockId::Latest),
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/equilibriumco/pathfinder-audit/issues/1141

A slow gateway pre-confirmed reply paired with a burst of preconfirmed targeted RPC requests will exhaust the DB pool for the duration of the cold-start timeout, because `get[_optional]` is called from within the same `spawn_blocking` block in which later a DB connection is acquired from the connection pool.

This PR refactors `get[_optional]` into an async `resolve` and sync `validate` that separate two concerns:
- resolving fresh preconfirmed data from the gateway,
- validating resolved preconfirmed data against the current commit head.

This way a well-timed burst of RPC requests will not exhaust any crucial resources apart from temporarily (ie. for the duration of the cold-start timeout) decreasing the amount of available permits (`--max-rpc-connections`), which should not be an issue as per-IP rate limiting should be performed by an upper layer (an API gateway).

I added some more RPC-specific block id types to replace runtime invariants with typesafe invariants. 