### PR TITLE
chore: bump version to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ More expansive patch notes and explanations may be found in the specific [pathfi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.24.0] - 2026-09-01
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "feeder-gateway"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "fake",
  "libp2p-identity",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_proto_derive"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8578,7 +8578,7 @@ dependencies = [
 
 [[package]]
 name = "p2p_stream"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8708,7 +8708,7 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathfinder"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8791,7 +8791,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-block-commitments"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-block-hashes"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8817,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-casm-hashes"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-class-hash"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "fake",
@@ -8844,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-common"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-compiler"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet 1.0.0-alpha.6",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-consensus"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-consensus-fetcher"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "pathfinder-common",
@@ -8929,7 +8929,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "ark-ff 0.5.0",
  "assert_matches",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-ethereum"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-executor"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-gas-price"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "apollo_versioned_constants",
  "mockall 0.14.0",
@@ -9004,7 +9004,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-merkle-tree"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -9020,7 +9020,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-pending-data"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "pathfinder-common",
@@ -9032,7 +9032,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-rpc"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -9096,7 +9096,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-serde"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -9112,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-storage"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9176,7 +9176,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-validator"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "pathfinder-version"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "vergen-gitcl",
 ]
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-client"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11293,7 +11293,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-test-fixtures"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "pathfinder-common",
  "pathfinder-crypto",
@@ -11301,7 +11301,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-gateway-types"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "fake",
@@ -12431,7 +12431,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "util"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = ["crates/load-test", "utils/pathfinder-probe"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.91"

--- a/crates/class-hash/Cargo.toml
+++ b/crates/class-hash/Cargo.toml
@@ -17,8 +17,8 @@ categories = [
 
 [dependencies]
 anyhow = { workspace = true }
-pathfinder-common = { version = "0.23.1", path = "../common" }
-pathfinder-crypto = { version = "0.23.1", path = "../crypto" }
+pathfinder-common = { version = "0.24.0", path = "../common" }
+pathfinder-crypto = { version = "0.24.0", path = "../crypto" }
 primitive-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision", "raw_value"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -29,7 +29,7 @@ metrics = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = "0.2"
 paste = { workspace = true }
-pathfinder-crypto = { version = "0.23.1", path = "../crypto" }
+pathfinder-crypto = { version = "0.24.0", path = "../crypto" }
 pathfinder-tagged = { version = "0.1.0", path = "../tagged" }
 pathfinder-tagged-debug-derive = { version = "0.1.0", path = "../tagged-debug-derive" }
 primitive-types = { workspace = true, features = ["serde"] }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -18,8 +18,8 @@ malachite-consensus = { package = "informalsystems-malachitebft-core-consensus",
 malachite-metrics = { package = "informalsystems-malachitebft-metrics", version = "0.5" }
 malachite-signing-ed25519 = { package = "informalsystems-malachitebft-signing-ed25519", version = "0.5", features = ["serde"] }
 malachite-types = { package = "informalsystems-malachitebft-core-types", version = "0.5" }
-pathfinder-common = { version = "0.23.1", path = "../common" }
-pathfinder-crypto = { version = "0.23.1", path = "../crypto" }
+pathfinder-common = { version = "0.24.0", path = "../common" }
+pathfinder-crypto = { version = "0.24.0", path = "../crypto" }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/load-test/Cargo.lock
+++ b/crates/load-test/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pathfinder-crypto"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "bitvec",
  "fake",

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -18,8 +18,8 @@ categories = [
 [dependencies]
 anyhow = { workspace = true }
 num-bigint = { workspace = true }
-pathfinder-common = { version = "0.23.1", path = "../common" }
-pathfinder-crypto = { version = "0.23.1", path = "../crypto" }
+pathfinder-common = { version = "0.24.0", path = "../common" }
+pathfinder-crypto = { version = "0.24.0", path = "../crypto" }
 primitive-types = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
Automated release PR for `0.24.0`.
